### PR TITLE
Add Dockerfile creating nginx image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.17-alpine
+
+RUN echo "<h1>athenian.co</h1>" > /usr/share/nginx/html/index.html
+
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # athenian-webapp
 Webapp for the Athenian product
+
+
+## Contributing
+
+Please refer to [our Contribution Guide](docs/CONTRIBUTING.md) for more details about developing the app.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contribution Guidelines
+
+In order to locally build Athenian web app image, and run it, run:
+
+```bash
+$ docker build --tag=athenian-app .
+$ docker run --rm --publish=8080:80 --name=athenian-app athenian-app
+```
+
+Then you can open http://localhost:8080 in your browser, and see the Athenian web app.


### PR DESCRIPTION
Once a container using this image is run, it will serve a `hello world` message.

In order to locally build Athenian web app image, and run it, run:

```bash
$ docker build --tag=athenian-app .
$ docker run --rm --publish=8080:80 --name=athenian-app athenian-app
```

Then you can open http://localhost:8080 in your browser, and see the Athenian web app.
