### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+  - node
+
+os:
+  - linux
+
+stages:
+  - name: test
+
+jobs:
+  include:
+    - name: 'Tests'
+      stage: test
+      script:
+        - echo "done"


### PR DESCRIPTION
required by [ENG-4]
blocks #4

Once this is merged, and once this repo is enabled in Athenian Travis, we will have CI running over webapp.

Here is an example of the passing build, running in my personal Travis account:
https://travis-ci.org/dpordomingo/athenian-webapp/jobs/620573008

[ENG-4]: https://athenianco.atlassian.net/browse/ENG-4