### PR TITLE
Dockerize the webapp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+/.git
+/.github
+/build
+/docs
+/node_modules
+.dockerignore
+.gitignore
+Dockerfile
+MAINTAINERS
+README.md
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ os:
 stages:
   - name: test
   - name: build
+  - name: deploy
+    if: branch = master AND type = push
 
 jobs:
   fast_finish: true
@@ -20,3 +22,8 @@ jobs:
       name: 'Frontend Build'
       script:
         - yarn build
+    - stage: deploy
+      name: 'Deploy Athenian Webapp'
+      script:
+        - docker build --tag=athenian-app:$TRAVIS_COMMIT .
+        #- docker push athenian-app:$TRAVIS_COMMIT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,21 @@
+# Build web app
+# ----------------
+FROM node:13.1-alpine AS app-builder
+
+WORKDIR /app
+
+COPY package.json .
+COPY yarn.lock .
+RUN yarn install
+
+COPY / .
+RUN yarn build
+
+
+# Build server
+# ----------------
 FROM nginx:1.17-alpine
 
-RUN echo "<h1>athenian.co</h1>" > /usr/share/nginx/html/index.html
+COPY --from=app-builder /app/build /usr/share/nginx/html
 
 ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
fix [[ENG-4]]
relates to [[ENG-6]]

Once this is merged, we will have the webapp dockerized, and running tests and builds from Travis as in this example in mi personal Travis account:
:point_right:  https://travis-ci.org/dpordomingo/athenian-webapp/builds/621079586

**TODO:**
- `docker push` is not yet ready, because I don't know where are we pushing.

[ENG-4]: https://athenianco.atlassian.net/browse/ENG-4
[ENG-6]: https://athenianco.atlassian.net/browse/ENG-6