### PR TITLE
Override bootstrap grid sizes to fit athenian layout

### DIFF
--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -1,4 +1,4 @@
-$body-bg: #f5f5f5;
+@import './overrides.scss';
 
 @import '~react-vis/dist/style.css';
 

--- a/src/sass/overrides.scss
+++ b/src/sass/overrides.scss
@@ -1,0 +1,33 @@
+/**
+ * Override grid sizes
+ * https://getbootstrap.com/docs/4.3/layout/grid/#variables
+ */
+
+$grid-gutter-width: 20px;
+
+$grid-breakpoints: (
+    // Phone
+    xs: 0,
+    // Tablet
+    sm: 768px,
+    // Small screen
+    md: 992px,
+    // Medium screen
+    lg: 1200px,
+    // Large screen
+    xl: 1300px,
+);
+
+$container-max-widths: (
+    sm: 720px,
+    md: 960px,
+    lg: 1140px,
+    xl: 1270px
+);
+
+/**
+ * Override global settings
+ * https://getbootstrap.com/docs/4.3/content/typography/#global-settings
+ */
+
+$body-bg: #f5f5f5;


### PR DESCRIPTION
blocked by #19

_Changes to be reviewed only by 1127c522bf056a2798c4398c1ee1a4550370855b_

Override bootstrap grid sizes to fit athenian layout:

Main new values:
- grid-gutter-width: 20px instead of 30px
- grid-breakpoints: xl -> 1300px instead of 1200px
- container-max-widths: xl -> 1270px instead of 1140px

see original values at https://getbootstrap.com/docs/4.3/layout/grid/#variables

