### PR TITLE
ENG-83 Use API metrics from thumbnails

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,84 +1,19 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import logo from './images/logos/logo-transparent.png';
 
 import Pipeline from './components/pipeline/Pipeline';
 
-const getData = () => [
-  { x: 0, y: 10 * Math.random() },
-  { x: 1, y: 10 * Math.random() },
-  { x: 2, y: 10 * Math.random() },
-  { x: 3, y: 10 * Math.random() },
-  { x: 4, y: 10 * Math.random() },
-  { x: 5, y: 10 * Math.random() },
-  { x: 6, y: 10 * Math.random() },
-  { x: 7, y: 10 * Math.random() },
-  { x: 8, y: 10 * Math.random() },
-  { x: 9, y: 10 * Math.random() }
-];
+import { getPipelineDataInitial, getPipelineDataAPI } from './services/api.js'
 
-const sampleCharts = [
-  {
-    title: 'Time to Commit in Base Branch',
-    color: '#62C2DF',
-    insights: [
-      { title: "insight 1", value: "foobar 1" },
-      { title: "insight 2", value: "foobar 2" }
-    ]
-  },
-  {
-    title: 'Time to Release',
-    color: '#FA1D62',
-    insights: [
-      { title: "insight 3", value: "foobar 3" }
-    ]
-  },
-  {
-    title: 'Merged Pull Request',
-    color: '#FF7D3A',
-    insights: []
-  },
-];
+export default () => {
+  const [pipelineState, setPipelineData] = useState(getPipelineDataInitial());
 
-const pipeline = [
-  {
-    tab: { title: 'PR created', color: '#FF7D3A', text: '2 days', badge: 10 },
-    body: { charts: sampleCharts }
-  },
-  {
-    tab: { title: 'Work in progress', color: '#FA1D62', text: '5 weeks', badge: 235 },
-    body: { charts: sampleCharts }
-  },
-  {
-    tab: { title: 'first review', color: '#FF7D3A', text: '10 months', badge: 5 },
-    body: { charts: sampleCharts }
-  },
-  {
-    tab: { title: 'approval', color: '#9460DA', text: '4 days', badge: 15 },
-    body: { charts: sampleCharts }
-  },
-  {
-    tab: { title: 'PR merged', color: '#FF7D3A', text: '5 weeks', badge: 33 },
-    body: { charts: sampleCharts }
-  },
-  {
-    tab: { title: 'release', color: '#62C2DF', text: '3 days', badge: 12 },
-    body: { charts: sampleCharts }
-  },
-];
-
-export default function () {
-
-  const data = pipeline.map((stage, i) => {
-    return {
-      tab: { ...stage.tab, data: getData() },
-      body: {
-        charts: stage.body.charts.map(c => {
-          return { ...c, title: c.title + ' ' + i, data: getData() }
-        })
-      }
-    }
-  });
+  useEffect(() => {
+    getPipelineDataAPI().then(data => {
+      setPipelineData(data);
+    });
+  }, []);
 
   return (
     <React.StrictMode>
@@ -108,7 +43,7 @@ export default function () {
       </nav>
 
       <div className="container">
-        <Pipeline pipeline={data} />
+        <Pipeline pipeline={pipelineState} />
       </div>
 
       <footer className="sticky-footer bg-white">

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,144 @@
+export const getPipelineDataInitial = () => getPipelineData([], () => []);
+
+const SECOND = 1;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+const getHours = secondsString => {
+  if (!secondsString) {
+    return 0;
+  };
+
+  const seconds = parseFloat(secondsString);
+  if (!seconds) {
+    return 0;
+  };
+
+  return seconds / HOUR;
+};
+
+export const getPipelineDataAPI = () => {
+  const metrics = ['pr-lead-time', 'pr-wip-time', 'pr-wait-first-review-time', 'pr-review-time', 'pr-merging-time', 'pr-release-time'];
+
+  return api(metrics).then(apiData => {
+    const thumbsData = [];
+
+    apiData.calculated[0].values.forEach(day => {
+      day.values.forEach((value, metricNo) => {
+        if (!thumbsData[metricNo]) {
+          thumbsData[metricNo] = [];
+        }
+
+        thumbsData[metricNo].push({ x: new Date(day.date), y: getHours(value) });
+      });
+    });
+
+    return getPipelineData(thumbsData, getRandData);
+  })
+};
+
+const sampleCharts = [
+  {
+    title: 'Time to Commit in Base Branch',
+    color: '#62C2DF',
+    insights: [
+      { title: "insight 1", value: "foobar 1" },
+      { title: "insight 2", value: "foobar 2" }
+    ]
+  },
+  {
+    title: 'Time to Release',
+    color: '#FA1D62',
+    insights: [
+      { title: "insight 3", value: "foobar 3" }
+    ]
+  },
+  {
+    title: 'Merged Pull Request',
+    color: '#FF7D3A',
+    insights: []
+  },
+];
+
+const pipeline = [
+  {
+    tab: { title: 'PR created', color: '#FF7D3A', text: '2 days', badge: 10, metric: 'pr-lead-time' },
+    body: { charts: sampleCharts }
+  },
+  {
+    tab: { title: 'Work in progress', color: '#FA1D62', text: '5 weeks', badge: 235, metric: 'pr-wip-time' },
+    body: { charts: sampleCharts }
+  },
+  {
+    tab: { title: 'first review', color: '#FF7D3A', text: '10 months', badge: 5, metric: 'pr-wait-first-review-time' },
+    body: { charts: sampleCharts }
+  },
+  {
+    tab: { title: 'approval', color: '#9460DA', text: '4 days', badge: 15, metric: 'pr-review-time' },
+    body: { charts: sampleCharts }
+  },
+  {
+    tab: { title: 'PR merged', color: '#FF7D3A', text: '5 weeks', badge: 33, metric: 'pr-merging-time' },
+    body: { charts: sampleCharts }
+  },
+  {
+    tab: { title: 'release', color: '#62C2DF', text: '3 days', badge: 12, metric: 'pr-release-time' },
+    body: { charts: sampleCharts }
+  },
+];
+
+const api = metrics => {
+  const repos = [
+    'github.com/athenianco/athenian-webapp',
+    'github.com/athenianco/athenian-api',
+    'github.com/athenianco/metadata',
+    'https://github.com/athenianco/metadata-retrieval'
+  ];
+  const granularity = 'week';
+
+  const dateFrom = '2019-11-19';
+  const dateTo = '2020-02-11';
+
+  const query = {
+    'for': [{
+      'repositories': repos,
+    }],
+    'metrics': metrics,
+    'date_from': dateFrom,
+    'date_to': dateTo,
+    'granularity': granularity,
+  };
+
+  const options = {
+    method: 'POST',
+    body: JSON.stringify(query)
+  };
+
+  let url = 'https://api.owl.athenian.co/v1/metrics_line';
+
+  return fetch(url, options)
+    .then(response => response.json());
+};
+
+
+const getPipelineData = (thumbData, randGenerator) => pipeline.map((stage, i) => {
+  return {
+    tab: { ...stage.tab, data: thumbData[i] },
+    body: {
+      charts: stage.body.charts.map(c => ({ ...c, title: c.title + ' ' + i, data: randGenerator() }))
+    }
+  }
+});
+
+const getRandData = () => [
+  { x: 0, y: 10 * Math.random() },
+  { x: 1, y: 10 * Math.random() },
+  { x: 2, y: 10 * Math.random() },
+  { x: 3, y: 10 * Math.random() },
+  { x: 4, y: 10 * Math.random() },
+  { x: 5, y: 10 * Math.random() },
+  { x: 6, y: 10 * Math.random() },
+  { x: 7, y: 10 * Math.random() },
+  { x: 8, y: 10 * Math.random() },
+  { x: 9, y: 10 * Math.random() }
+];


### PR DESCRIPTION
fix [[ENG-83]] Call the API to fill the cards with the data returned

This PR calls the API to get thumbnails metrics. It's still a _poc_ to be evolved as we start adding use cases and have real data and stop mocking.

## TODO for the API
The following improvements in the API side would be very welcome in the frontend:

- [[ENG-122]] Only zero-values in `lead-time`, `wait-first-review-time`, `merging-time` and `release-time`

![image](https://user-images.githubusercontent.com/2437584/72129331-22ba1780-3376-11ea-8e49-648e489846a6.png)
Some thumbnails lack chart because per [[ENG-122]] its metrics returns only `zero-values`.

[ENG-83]: https://athenianco.atlassian.net/browse/ENG-83
[ENG-125]: https://athenianco.atlassian.net/browse/ENG-125
[ENG-122]: https://athenianco.atlassian.net/browse/ENG-122