### PR TITLE
Fix pipeline thumb chart sizing

### DIFF
--- a/src/components/charts/CleanAreaChart.js
+++ b/src/components/charts/CleanAreaChart.js
@@ -28,7 +28,7 @@ export default ({ fill, stroke, data }) => {
   }
 
   return (
-    <FlexibleXYPlot>
+    <FlexibleXYPlot margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
       <GradientDefs>
         {gradients}
       </GradientDefs>

--- a/src/components/pipeline/PipelineCard.js
+++ b/src/components/pipeline/PipelineCard.js
@@ -14,7 +14,7 @@ export default ({ title, text, badge, color, data, active, onClick }) => {
   return (
     <div className={"card shadow pipeline-thumbnail" + (active ? ' active' : '')} onClick={onClick} style={cardStyle}>
       <div className="card-body">
-        <div className="row no-gutters card-title text-xs text-uppercase">
+        <div className="row no-gutters card-title text-xs text-uppercase mb-3">
           <div className="col font-weight-bold">{title}</div>
           <div className="col-auto">
             <span className="badge badge-pill badge-secondary align-middle py-1 px-2">{badge}</span>
@@ -22,7 +22,7 @@ export default ({ title, text, badge, color, data, active, onClick }) => {
         </div>
         <div className="row no-gutters card-text">
           <div className="col-5 text-md font-weight-bold">{text}</div>
-          <div className="col-7 pl-2" style={{ height: 80 }}>
+          <div className="col-7 pl-2" style={{ height: 40 }}>
             <PipelineCardMiniChart data={data} color={color} active={active} />
           </div>
         </div>


### PR DESCRIPTION
Pipeline thumbnails should be smaller.
Its charts were not properly rendered because of a lack of config.

Before:
![image](https://user-images.githubusercontent.com/2437584/72746533-a2d05080-3bb2-11ea-978f-ca4574e751f6.png)

After:
![image](https://user-images.githubusercontent.com/2437584/72746795-4c174680-3bb3-11ea-8b4d-7ed1b3987bdf.png)


Design:
![image](https://user-images.githubusercontent.com/2437584/72746644-e32fce80-3bb2-11ea-8142-bf3907427172.png)
