### PR TITLE
[Hotfix] Update node-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 # Build web app
 # ----------------
-FROM node:13.1-alpine AS app-builder
+FROM node:13.7-alpine AS app-builder
 
 WORKDIR /app
 
 COPY package.json .
 COPY yarn.lock .
-RUN make dependencies
+COPY Makefile .
+
+RUN apk update && \
+    apk add make git bash && \
+    make dependencies
 
 COPY / .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,10 @@ test:
 generate: api-generate
 
 .PHONY: dependencies
-dependencies: api-dependencies
+dependencies: app-dependencies
 
-.PHONY: api-dependencies
-api-dependencies:
+.PHONY: app-dependencies
+app-dependencies:
 	yarn install
 
-$(OPENAPI_GENERATOR): api-dependencies
+$(OPENAPI_GENERATOR): app-dependencies


### PR DESCRIPTION
There was a problem rebuilding node-gyp which also seems to need python2 and is not available. It's fixed in the latest release of `node-alpine`.
I guess the error appeared when trying to build any new dependency added (or updated) by https://github.com/athenianco/athenian-webapp/pull/25

Also it was needed the  inside the image in order run 'make' commands to install and build the app