### PR TITLE
Add Development.Breakpoints tool to reveal breakpoints

### DIFF
--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -6,6 +6,7 @@ import Routes from 'js/Routes';
 import * as serviceWorker from 'js/services/serviceWorker';
 import { Auth0Provider } from 'js/services/react-auth0-spa';
 import history from 'js/services/history';
+import Development from 'js/components/development';
 
 // A function that routes the user to the right place
 // after login
@@ -17,7 +18,7 @@ const onRedirectCallback = appState => {
   );
 };
 
-ReactDOM.render(
+ReactDOM.render(<>
   <Auth0Provider
     domain={window.ENV.auth.domain}
     client_id={window.ENV.auth.clientId}
@@ -25,7 +26,9 @@ ReactDOM.render(
     onRedirectCallback={onRedirectCallback}
   >
     <Routes />
-  </Auth0Provider>,
+  </Auth0Provider>
+  {process.env.NODE_ENV === 'development' && <Development.Breakpoints />}
+</>,
   document.getElementById('root')
 );
 

--- a/src/js/components/development/index.jsx
+++ b/src/js/components/development/index.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import 'js/components/development/index.scss';
+
+export default {
+    Breakpoints: () => (
+        <div id="breakpoint-helper">
+            <div className="breakPoints">
+                <div className="breakPoint" id="xs">
+                    <span className="desc">Phone</span>
+                    <span className="size">(0px)</span>
+                    <span className="name">xs</span>
+                </div>
+                <div className="breakPoint" id="sm">
+                    <span className="desc">Tablet</span>
+                    <span className="size">(768px)</span>
+                    <span className="name">sm</span>
+                </div>
+                <div className="breakPoint" id="md">
+                    <span className="desc">Small screen</span>
+                    <span className="size">(992px)</span>
+                    <span className="name">md</span>
+                </div>
+                <div className="breakPoint" id="lg">
+                    <span className="desc">Medium screen</span>
+                    <span className="size">(1200px)</span>
+                    <span className="name">lg</span>
+                </div>
+                <div className="breakPoint" id="xl">
+                    <span className="desc">Large screen</span>
+                    <span className="size">(1300px)</span>
+                    <span className="name">xl</span>
+                </div>
+            </div>
+        </div>
+    )
+};

--- a/src/js/components/development/index.scss
+++ b/src/js/components/development/index.scss
@@ -1,0 +1,81 @@
+@import 'sass/_variables.scss';
+@import 'sass/_overrides.scss';
+@import '~@dpordomingo/startbootstrap-sb-admin-2/scss/sb-admin-2.scss';
+
+#breakpoint-helper {
+    position: fixed;
+    bottom: 3px;
+    right: 3px;
+    text-align: right;
+    cursor: help;
+    display: block;
+    border: 1px solid #888;
+    background-color: #ddd;
+
+    &:hover {
+        .breakPoints {
+            display: block;
+        }
+    }
+
+    .name,
+    .desc,
+    .size {
+        display: inline-block;
+        line-height: 20px;
+    }
+
+    .name,
+    .size {
+        text-align: center;
+    }
+
+    .size {
+        width: 50px;
+        font-size: 9px;
+    }
+
+    .name {
+        width: 30px;
+        font-family: courier;
+    }
+
+    .desc {
+        padding-left: 5px;
+    }
+
+    .breakPoint {
+        display: none;
+    }
+
+    #xs {
+        @include media-breakpoint-only(xs) {
+            display: block;
+        }
+    }
+
+    #sm {
+        @include media-breakpoint-only(sm) {
+            display: block;
+        }
+    }
+
+    #md {
+        @include media-breakpoint-only(md) {
+            display: block;
+        }
+    }
+
+    #lg {
+        @include media-breakpoint-only(lg) {
+            display: block;
+        }
+    }
+
+    #xl {
+        @include media-breakpoint-up(xl) {
+            display: block;
+        }
+    }
+
+}


### PR DESCRIPTION
used by #43 and #44

When running the project development (`make serve`), it will appear in the right-bottom corner a small container revealing the current breakpoint based in current bootstrap config.

<img src="https://user-images.githubusercontent.com/2437584/73345784-fd3d7100-4284-11ea-9331-77c55476036d.png" width=500 />

The compiled version (`make build`) does not add this helper.