### PR TITLE
Add Bearer auth header for api calls

### DIFF
--- a/src/js/pages/Home.jsx
+++ b/src/js/pages/Home.jsx
@@ -4,17 +4,33 @@ import Pipeline from 'js/components/pipeline/Pipeline';
 import PullRequests from 'js/components/pipeline/PullRequests';
 import Page from 'js/pages/templates/Page';
 
-import { getPipelineDataInitial, getPipelineDataAPI, getPRs } from 'js/services/api';
+import { getPipelineDataInitial, getPipelineDataAPI, getPRs, fetchApi } from 'js/services/api';
+
+import { useAuth0 } from "../services/react-auth0-spa";
 
 export default () => {
+  const { loading, isAuthenticated, getTokenSilently } = useAuth0();
+
   const [pipelineState, setPipelineData] = useState(getPipelineDataInitial());
   const [prsState, _] = useState(getPRs());
 
   useEffect(() => {
-    getPipelineDataAPI().then(data => {
-      setPipelineData(data);
-    });
-  }, []);
+    const callAPI = async () => {
+      if (loading || !isAuthenticated) {
+        return;
+      };
+
+      getTokenSilently()
+        .then(token => {
+          return fetchApi(token, getPipelineDataAPI);
+        })
+        .then(data => {
+          setPipelineData(data);
+        });
+    };
+
+    callAPI();
+  }, [loading, isAuthenticated, getTokenSilently]);
 
   return (
     <Page>

--- a/src/js/pages/templates/Page.jsx
+++ b/src/js/pages/templates/Page.jsx
@@ -3,18 +3,31 @@ import React, { useState, useEffect } from 'react';
 import Navbar from 'js/components/layout/Navbar';
 import Footer from 'js/components/layout/Footer';
 
-import { getUser } from 'js/services/api';
+import { getUser, fetchApi } from 'js/services/api';
 import { useAuth0 } from 'js/services/react-auth0-spa';
 
 export default ({ children }) => {
+  const { loading, isAuthenticated, getTokenSilently } = useAuth0();
+
   const [userState, setUser] = useState(null);
-  const { isAuthenticated } = useAuth0();
 
   useEffect(() => {
-    if (isAuthenticated) {
-      getUser().then(setUser);
-    }
-  }, []);
+    const callAPI = async () => {
+      if (loading || !isAuthenticated) {
+        return;
+      };
+
+      getTokenSilently()
+        .then(token => {
+          return fetchApi(token, getUser);
+        })
+        .then(data => {
+          setUser();
+        });
+    };
+
+    callAPI();
+  }, [loading, isAuthenticated, getTokenSilently]);;
 
   return (
     <>

--- a/src/js/services/api/openapi-client/ApiClient.js
+++ b/src/js/services/api/openapi-client/ApiClient.js
@@ -41,6 +41,7 @@ class ApiClient {
          * @type {Array.<String>}
          */
         this.authentications = {
+            'bearerAuth': {type: 'bearer'} // JWT
         }
 
         /**

--- a/src/js/services/api/openapi-client/api/DefaultApi.js
+++ b/src/js/services/api/openapi-client/api/DefaultApi.js
@@ -68,7 +68,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = InvitedUser;
@@ -113,7 +113,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = CalculatedMetrics;
@@ -201,7 +201,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = CreatedIdentifier;
@@ -248,7 +248,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = Object;
@@ -294,7 +294,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = InvitationLink;
@@ -340,7 +340,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = Account;
@@ -386,7 +386,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = ['String'];
@@ -426,7 +426,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = User;
@@ -471,7 +471,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = [];
       let accepts = ['application/json'];
       let returnType = [RepositorySetListItem];
@@ -520,7 +520,7 @@ export default class DefaultApi {
       let formParams = {
       };
 
-      let authNames = [];
+      let authNames = ['bearerAuth'];
       let contentTypes = ['application/json'];
       let accepts = ['application/json'];
       let returnType = Object;


### PR DESCRIPTION
This adds the authentication header with the bearer token required by the api.

For now, it has been added only to `getUser` and `getPipelineDataAPI`. I'd suggest refactoring better the code once we have more calls to the apis. So far I just copy-pasted the same snippet of code for the two above mentioned api calls.

The first commit simply updates the client code according to the updated spec that includes security schema.