### PR TITLE
Fix guest feature, and workaround for API fails

### DIFF
--- a/src/js/pages/pipeline/Overview.jsx
+++ b/src/js/pages/pipeline/Overview.jsx
@@ -16,12 +16,19 @@ export default () => {
     const [prsState] = useState(getPRs());
 
     useEffect(() => {
-        if (loading || !isAuthenticated) {
+        if (loading) {
             return;
         };
-        getTokenSilently()
-            .then(token => fetchApi(token, getPipelineDataAPI))
-            .then(setPipelineData);
+
+        let pipelinePromise;
+        if (isAuthenticated) {
+            pipelinePromise = getTokenSilently()
+                .then(token => fetchApi(token, getPipelineDataAPI));
+        } else {
+            pipelinePromise = fetchApi('', getPipelineDataAPI);
+        }
+
+        pipelinePromise.then(setPipelineData);
     }, [loading, isAuthenticated, getTokenSilently]);
 
     return (

--- a/src/js/pages/pipeline/Stage.jsx
+++ b/src/js/pages/pipeline/Stage.jsx
@@ -19,12 +19,19 @@ export default () => {
     const activeStageState = pipelineState.findIndex(stage => stage.tab.slug === name);
 
     useEffect(() => {
-        if (loading || !isAuthenticated) {
+        if (loading) {
             return;
         };
-        getTokenSilently()
-            .then(token => fetchApi(token, getPipelineDataAPI))
-            .then(setPipelineData);
+
+        let pipelinePromise;
+        if (isAuthenticated) {
+            pipelinePromise = getTokenSilently()
+                .then(token => fetchApi(token, getPipelineDataAPI));
+        } else {
+            pipelinePromise = fetchApi('', getPipelineDataAPI);
+        }
+
+        pipelinePromise.then(setPipelineData);
     }, [loading, isAuthenticated, getTokenSilently]);
 
     const links = {

--- a/src/js/pages/templates/Page.jsx
+++ b/src/js/pages/templates/Page.jsx
@@ -18,7 +18,10 @@ export default ({ breadcrumbs, children }) => {
 
     getTokenSilently()
       .then(token => fetchApi(token, getUser))
-      .then(setUser);
+      .then(setUser)
+      .catch(e => setUser({})); // TODO (dpordomingo):
+    // if could not get the user, but Auth0 is in logged in state, it will set an empty user
+    // We'll handle errors later, but this is blocker to ensure that at least the user can logout.
   }, [loading, isAuthenticated, getTokenSilently]);;
 
   return (


### PR DESCRIPTION
caused by https://github.com/athenianco/athenian-webapp/pull/46#discussion_r373456996

This hotfix will:
- let the visitor see data as guest (using guest user, as automatically set by the API)
- if after logging the API can not process the token from Auth0, it will be shown an empty user but keeping the 'isAuthenticated' state, so the user will still be able to logout.