### PR TITLE
Auth handshake webapp <> api

### DIFF
--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -8,14 +8,16 @@ import { Auth0Provider } from 'js/services/react-auth0-spa';
 import history from 'js/services/history';
 import Development from 'js/components/development';
 
+import {
+  Redirect,
+} from 'react-router-dom';
+
+
 // A function that routes the user to the right place
 // after login
 const onRedirectCallback = appState => {
-  history.push(
-    appState && appState.targetUrl
-      ? appState.targetUrl
-      : window.location.pathname
-  );
+  let qp = new URLSearchParams(appState).toString();
+  history.push('/callback?' + qp);
 };
 
 ReactDOM.render(<>

--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -4,6 +4,7 @@ import {
   Router,
   Switch,
   Route,
+  Redirect,
 } from 'react-router-dom';
 
 import history from 'js/services/history';
@@ -30,12 +31,21 @@ export default () => {
           <Route path='/stage/:name'>
             <Stage />
           </Route>
+          <Route
+            path='/i/:code(\w{8})'
+            render={props => (
+              <Redirect to={
+                {
+                  pathname: '/login',
+                  state: { inviteLink: window.location.href }
+                }
+              }/>
+            )}
+          />
           <Route path='/login/callback'>
             <Callback />
           </Route>
-          <Route path='/login'>
-            <Login />
-          </Route>
+          <Route path='/login' component={Login} />
           <Route path='/logout'>
             <Logout />
           </Route>

--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -42,7 +42,7 @@ export default () => {
               }/>
             )}
           />
-          <Route path='/login/callback'>
+          <Route path='/callback'>
             <Callback />
           </Route>
           <Route path='/login' component={Login} />

--- a/src/js/pages/auth/Callback.jsx
+++ b/src/js/pages/auth/Callback.jsx
@@ -1,10 +1,55 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+import { useLocation, Redirect } from 'react-router-dom';
 
 import { useAuth0 } from 'js/services/react-auth0-spa';
 import Simple from 'js/pages/templates/Simple';
 
+import { buildApi } from 'js/services/api';
+import InvitationLink from 'js/services/api/openapi-client/model/InvitationLink';
+
 export default () => {
-  const { loading, isAuthenticated } = useAuth0();
+  const { loading, isAuthenticated, getTokenSilently } = useAuth0();
+  const [redirectTo, setRedirectTo] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const query = new URLSearchParams(useLocation().search);
+
+  useEffect(() => {
+    if (loading || !isAuthenticated) {
+      return;
+    };
+
+    getTokenSilently()
+      .then(token => {
+        const api = buildApi(token);
+        const inviteLink = query.get('inviteLink');
+
+        if (inviteLink) {
+          const body = new InvitationLink(inviteLink);
+          api.checkInvitation(body)
+            .then(check => {
+              if (check.valid && check.active) {
+                const invType = check.type;
+                return api.acceptInvitation(body);
+              }
+
+              return Promise.reject(new Error('invalid invitation'));
+            })
+            .then(resp => setRedirectTo(query.get('targetUrl')))
+            .catch(err => setErrorMessage(err.message));
+        } else {
+          setRedirectTo(query.get('targetUrl'));
+        }
+      });
+  }, [loading, isAuthenticated]);;
+
+  if (redirectTo) {
+    return <Redirect to={redirectTo}/>;
+  }
+
+  if (errorMessage) {
+    return <Simple>{errorMessage}</Simple>;
+  }
 
   if (loading) {
     return <Simple>Loading...</Simple>;

--- a/src/js/pages/auth/Login.jsx
+++ b/src/js/pages/auth/Login.jsx
@@ -4,7 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { useAuth0 } from 'js/services/react-auth0-spa';
 import Simple from 'js/pages/templates/Simple';
 
-export default () => {
+export default ({location}) => {
   const history = useHistory();
   const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
 
@@ -16,16 +16,20 @@ export default () => {
     history.push('/');
   }
 
+  const appState = {
+    targetUrl: '/waiting',
+  };
+
+  if (location.state && location.state.inviteLink) {
+    appState.inviteLink = location.state.inviteLink;
+  }
+
   return (
     <Simple>
       <button
         type="button"
         className="btn btn-primary btn-lg"
-        onClick={
-          () => loginWithRedirect({
-            appState: { targetUrl: "/waiting" }
-          })
-        }
+        onClick={() => loginWithRedirect({appState: appState})}
       >
         Login
       </button>

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -139,12 +139,16 @@ const fetchApiMetricsLine = (api, metrics) => {
   return api.calcMetricsLine(body);
 };
 
-export const fetchApi = (token, apiCall, ...args) => {
+export const buildApi = (token) => {
   const client = new ApiClient();
   client.authentications.bearerAuth.accessToken = token;
   client.basePath = window.ENV.api.basePath;
 
-  const api = new DefaultApi(client);
+  return new DefaultApi(client);
+};
+
+export const fetchApi = (token, apiCall, ...args) => {
+  const api = buildApi(token);
   return apiCall(api, ...args);
 };
 


### PR DESCRIPTION
This PR implements the followings:
- add a redirect from url matching the format of the admin invitation link to the login page,
- add the invitation link to the `appState` of Auth0 to make it available in the callback,
- change the Auth0 callback handler to always redirect to `/callback`,
- call `/v1/accept` endpoint of api if the invitation link correspond to an admin link,
- redirect to waiting page on succes.