### PR TITLE
Improve UX when accepting invitations

### DIFF
--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -8,11 +8,6 @@ import { Auth0Provider } from 'js/services/react-auth0-spa';
 import history from 'js/services/history';
 import Development from 'js/components/development';
 
-import {
-  Redirect,
-} from 'react-router-dom';
-
-
 // A function that routes the user to the right place
 // after login
 const onRedirectCallback = appState => {

--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -31,21 +31,20 @@ export default () => {
           <Route path='/stage/:name'>
             <Stage />
           </Route>
-          <Route
-            path='/i/:code(\w{8})'
-            render={props => (
-              <Redirect to={
-                {
-                  pathname: '/login',
-                  state: { inviteLink: window.location.href }
-                }
-              }/>
-            )}
-          />
+          <Route path='/i/:code(\w{8})'>
+            <Redirect to={
+              {
+                pathname: '/login',
+                state: { inviteLink: window.location.href }
+              }
+            } />
+          </Route>
           <Route path='/callback'>
             <Callback />
           </Route>
-          <Route path='/login' component={Login} />
+          <Route path='/login'>
+            <Login />
+          </Route>
           <Route path='/logout'>
             <Logout />
           </Route>

--- a/src/js/pages/auth/Callback.jsx
+++ b/src/js/pages/auth/Callback.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-
 import { useLocation, Redirect } from 'react-router-dom';
 
 import { useAuth0 } from 'js/services/react-auth0-spa';
@@ -9,7 +8,7 @@ import { buildApi } from 'js/services/api';
 import InvitationLink from 'js/services/api/openapi-client/model/InvitationLink';
 
 export default () => {
-  const { loading, isAuthenticated, getTokenSilently } = useAuth0();
+  const { loading, isAuthenticated, getTokenSilently, logout } = useAuth0();
   const [redirectTo, setRedirectTo] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const query = new URLSearchParams(useLocation().search);
@@ -20,31 +19,52 @@ export default () => {
     };
 
     getTokenSilently()
-      .then(token => {
+      .then(async (token) => {
         const api = buildApi(token);
         const inviteLink = query.get('inviteLink');
 
         if (inviteLink) {
           const body = new InvitationLink(inviteLink);
-          api.checkInvitation(body)
-            .then(check => {
-              if (check.valid && check.active) {
-                const invType = check.type;
-                return api.acceptInvitation(body);
-              }
 
-              return Promise.reject(new Error('invalid invitation'));
-            })
-            .then(resp => setRedirectTo(query.get('targetUrl')))
-            .catch(err => setErrorMessage(err.message));
-        } else {
-          setRedirectTo(query.get('targetUrl'));
+          try {
+
+            let check;
+            try {
+              check = await api.checkInvitation(body);
+            } catch (err) {
+              throw new Error(`${err.error.message}`);
+            }
+
+            if (!check.valid || !check.active) {
+              const cause = !check.valid ? 'valid' : 'active';
+              throw new Error(`Invitation is not ${cause}`);
+            }
+
+            try {
+              await api.acceptInvitation(body);
+            } catch (err) {
+              throw new Error(`Could not accept the invitation. Err#${err.body.status} ${err.body.type}. ${err.body.detail}`);
+            }
+
+          } catch (err) {
+            setErrorMessage(err.message);
+
+            // TODO (dpordomingo):
+            // This is needed because if the invitation fails, the user should not be logged in.
+            // Also, the logout is delayed because Auth0 redirects to the 'logoutRedirectUri'
+            // inmediately, and then the user would not be able to see the error message.
+            // Workaround: store the error, let Auth0 to redirect, and then show the stored message.
+            window.setTimeout(() => logout({ returnTo: window.ENV.auth.logoutRedirectUri }), 3000);
+            return;
+          }
         }
+
+        setRedirectTo(query.get('targetUrl'));
       });
   }, [loading, isAuthenticated]);;
 
   if (redirectTo) {
-    return <Redirect to={redirectTo}/>;
+    return <Redirect to={redirectTo} />;
   }
 
   if (errorMessage) {

--- a/src/js/pages/auth/Login.jsx
+++ b/src/js/pages/auth/Login.jsx
@@ -1,18 +1,27 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory, useLocation } from 'react-router-dom';
 
 import { useAuth0 } from 'js/services/react-auth0-spa';
 import Simple from 'js/pages/templates/Simple';
 
-export default ({location}) => {
+export default () => {
   const history = useHistory();
   const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
+  const location = useLocation();
 
   if (loading) {
     return <Simple>Loading...</Simple>;
   }
 
   if (isAuthenticated) {
+    if (location.state && location.state.inviteLink) {
+      return (
+        <Simple>
+          You must <Link to="/logout">logout</Link> first, and then open the invitation link.
+        </Simple>
+      )
+    }
+
     history.push('/');
   }
 
@@ -26,10 +35,13 @@ export default ({location}) => {
 
   return (
     <Simple>
+      {location.state && location.state.inviteLink && (
+        <p>Login to accept invitation {appState.inviteLink}</p>
+      )}
       <button
         type="button"
         className="btn btn-primary btn-lg"
-        onClick={() => loginWithRedirect({appState: appState})}
+        onClick={() => loginWithRedirect({ appState: appState })}
       >
         Login
       </button>


### PR DESCRIPTION
this will update #50

- Let the user know that is going to accept an invitation,
- Show errors that can happen when accepting an invitation:
  - when trying to accept an invitation being already logged in,
  - when the API is not responding,
  - when the invitation is not valid,
  - when the acceptance process crashed.
- Logout the user if the handshake could not be performed
  (so they can retry)

Other minors:
- Homogenize the new routes with the current ones
- Clean leftover

When trying to accept an invitation being logged:
![image](https://user-images.githubusercontent.com/2437584/74057373-0f858080-49e4-11ea-8955-31c5f982057c.png)

When accepting an invitation, and login is requested:
![image](https://user-images.githubusercontent.com/2437584/74057435-3ba10180-49e4-11ea-9def-0b5117bef984.png)

When the invitation is no valid
![image](https://user-images.githubusercontent.com/2437584/74057492-57a4a300-49e4-11ea-9336-361355dd6d99.png)
