### PR TITLE
Integrate PRs into overview

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -3,34 +3,180 @@ import $ from 'jquery';
 import 'datatables.net';
 import 'datatables.net-bs4';
 import 'datatables.net-bs4/css/dataTables.bootstrap4.css';
-import classnames from 'classnames';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCommentAlt, faFileAlt } from '@fortawesome/free-regular-svg-icons';
 
 import { SmallTitle } from 'js/components/ui/Typography';
 import Badge from 'js/components/ui/Badge';
 
+import { dateTime, github, number } from 'js/services/format';
+import { palette } from 'js/res/palette';
+
 export default ({ data }) => {
-    const statusClass = status => {
-        switch (status) {
-            case 'wip':
-                return 'border-warning text-warning';
-            case 'merged':
-                return 'border-success text-success';
-            case 'closed':
-                return 'border-danger text-danger';
-        };
+
+    const stageStyle = stage => `
+        border-color: ${palette.stages[stage]} !important;
+        color: ${palette.stages[stage]} !important;
+    `;
+
+    const userImage = user => {
+        if (users[user] && users[user].avatar) {
+            return `<img src="${users[user].avatar}" title="${github.userName(user)}" alt="${github.userName(user)}" class="pr-user-avatar" /><span class="pr-user-avatar pr-user-unknown" title="${github.userName(user)}" class="pr-user-unknown">?</span>`;
+        }
+
+        return `<span title="${github.userName(user)}" class="pr-user-avatar pr-user-unknown">?</span>`;
     }
 
-    useEffect(() => {
-        $('#dataTable').DataTable && $('#dataTable').DataTable({
-            searching: false,
-            ordering: false
-        });
-    }, [])
+    const { prs, users } = data;
 
-    return (
+    useEffect(() => {
+        if (!prs.length || !$('#dataTable').DataTable) {
+            return;
+        }
+
+        if ($.fn.DataTable.isDataTable('#dataTable')) {
+            console.log('Table already exists. Clearing.', $('#dataTable').DataTable().data().length);
+            $('#dataTable').DataTable().clear();//.draw();
+            return;
+        }
+
+        $('#dataTable').DataTable({
+            dom: `
+                <'row'<'col-12'f>>
+                <'row'<'col-12'tr>>
+                <'row'<'d-flex align-items-center col-sm-12 col-md-5'<'pt-3'l><'pb-2 ml-3'i>><'col-sm-12 col-md-7'p>>
+            `,
+            searching: true,
+            ordering: true,
+            fixedHeader: true,
+            data: prs,
+            columns: [
+                {
+                    title: '',
+                    className: 'pr-merged',
+                    render: (_, type, row) => {
+                        let pic, status;
+                        if (row.merged) {
+                            pic = '<i title="merged" class="fa fas fa-code-branch text-merge fa-rotate-180"></i>';
+                            status = 'merged';
+                        } else if (row.stage == 'wip' || row.stage == 'review' || row.stage == 'merge') {
+                            pic = '<i title="opened" class="fa fas fa-code-branch text-success"></i>';
+                            status = 'opened';
+                        } else {
+                            pic = '<i title="closed" class="fa fas fa-code-branch text-danger"></i>';
+                            status = 'closed';
+                        }
+
+                        switch (type) {
+                            case 'display':
+                                return pic;
+                            default:
+                                return status;
+                        }
+                    },
+                },
+                {
+                    title: 'Pull Requests',
+                    className: 'pr-main',
+                    render: (_, type, row) => {
+                        switch (type) {
+                            case 'display':
+                                return `
+                                    <div>
+                                        ${github.repoOrg(row.repository)}/${github.repoName(row.repository)}:
+                                        <strong><a href=${github.prLink(row.repository, row.number)} target="_blank">${row.title}</a></strong>
+                                    </div>
+                                    <div>
+                                        ${row.creators.map(userImage).join(' ')}
+                                        <span class="pr-created-by">created by <strong>${row.creators.map(github.userName).join(' ')}</strong></span>
+                                        ${dateTime.ago(row.created)} ago
+                                    </div>
+                                `;
+                            case 'sort':
+                                return row.number;
+                            default:
+                                return row.title;
+                        }
+                    },
+                }, {
+                    title: 'Age',
+                    searchable: false,
+                    className: 'pr-age',
+                    render: (_, type, row) => {
+                        switch (type) {
+                            case 'display':
+                                if (row.stage === 'release' || row.stage === 'done') {
+                                    return row.closed ? dateTime.interval(row.created, row.closed) : '';
+                                }
+                                return '';
+                            default:
+                                if (row.stage === 'release' || row.stage === 'done') {
+                                    return row.closed ? row.closed - row.created : Number.MAX_VALUE;
+                                }
+                                return Number.MAX_VALUE;
+                        }
+                    },
+                }, {
+                    title: 'Size',
+                    className: 'pr-size',
+                    searchable: false,
+                    render: (_, type, row) => {
+                        switch (type) {
+                            case 'display':
+                                return `
+                                    <i class="fa far fa-file-alt"></i>
+                                    <span class="mr-3">${number.si(row.files_changed)}</span>
+                                    <span class="text-success mr-1">+${number.si(row.size_added)}</span>
+                                    <span class="text-danger">-${number.si(row.size_removed)}</span>
+                                `;
+                            default:
+                                return row['files_changed'];
+                        }
+                    },
+                }, {
+                    title: 'Comments',
+                    searchable: false,
+                    render: (_, type, row) => {
+                        switch (type) {
+                            case 'display':
+                                return `<i class="fa far fa-comment-alt"></i>${row.comments + row.review_comments}`;
+                            default:
+                                return row['comments'] + row['review_comments'];
+                        }
+                    },
+                }, {
+                    title: 'Participants',
+                    className: 'pr-participants',
+                    render: (_, type, row) => {
+                        switch (type) {
+                            case 'display':
+                                return row.participants.map(userImage).join(' ');
+                            case 'sort':
+                                return row.participants.length;
+                            default:
+                                return row.participants.map(github.userName).join(' ') + row.creators.map(github.userName).join(' ');
+                        }
+                    },
+                }, {
+                    title: 'Stage',
+                    className: 'align-middle text-center',
+                    render: (_, type, row) => {
+                        switch (type) {
+                            case 'display':
+                                return `<div class="border rounded px-3 py-1" style="${stageStyle(row.stage)}">${row.stage}</div>`;
+                            default:
+                                return row.stage;
+                        }
+                    },
+                },
+            ],
+        });
+
+        return () => {
+            console.log('Unmounting table. Clearing.');
+            $('#dataTable').DataTable().destroy(true);
+        }
+    }, [prs])
+
+    return prs.length ? (
         <>
             <div className="row mb-4">
                 <div className="col-12">
@@ -38,57 +184,16 @@ export default ({ data }) => {
                         <div className="pr-tab card mr-2 p-0 border-0 border-bottom-primary rounded-top rounded-0 rounded-top bg-transparent">
                             <div className="card-body px-0 py-3">
                                 <SmallTitle content="Pull Requests" isBlack />
-                                <Badge value="33" className="ml-3" />
+                                <Badge value={prs.length} className="ml-3" />
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
 
-
             <div className="table-responsive mb-4">
-                <table className="table table-bordered" id="dataTable" width="100%" cellSpacing="0">
-                    <thead className="bg-secondary">
-                        <tr>
-                            <th><SmallTitle content="Pull Request | Creator" /></th>
-                            <th><SmallTitle content="Size" /></th>
-                            <th><SmallTitle content="Comments" /></th>
-                            <th><SmallTitle content="Participants" /></th>
-                            <th><SmallTitle content="Age" /></th>
-                            <th><SmallTitle content="Status" /></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {data.map && data.map((v, i) =>
-                            <tr key={i} className="bg-white">
-                                <td>
-                                    <div>{v.organization}/{v.repo}: <strong>{v.title}</strong></div>
-                                    <div>created by <strong>{v.creator}</strong></div>
-                                </td>
-                                <td>
-                                    <span className="mr-3">
-                                        <FontAwesomeIcon icon={faFileAlt} className="mr-1" />
-                                        {v.size}
-                                    </span>
-                                    <span className="text-success mr-2">+{v.lines.add}</span>
-                                    <span className="text-danger">-{v.lines.remove}</span>
-                                </td>
-                                <td>
-                                    <FontAwesomeIcon icon={faCommentAlt} className="align-middle mr-1" />
-                                    {v.comments}
-                                </td>
-                                <td>{v.participants.join(', ')}</td>
-                                <td>{v.age}</td>
-                                <td className="align-middle text-center"><div className={classnames('border rounded px-3 py-1', statusClass(v.status))}>{v.status}</div></td>
-                            </tr>
-                        )}
-                    </tbody>
-                </table>
+                <table className="table table-bordered" id="dataTable" width="100%" cellSpacing="0" />
             </div>
-
-
-
-
         </>
-    )
+    ) : ('')
 }

--- a/src/js/res/palette.js
+++ b/src/js/res/palette.js
@@ -8,6 +8,8 @@ export const palette = {
         mergeAlt: '#CCB9EC',
         release: '#35CB70',
         releaseAlt: '#BCE6CE',
+        done: 'red', // TODO (dpordomingo): 'done' stage is defined in the API, but not in the Product designs
+        doneAlt: 'red', // TODO (dpordomingo): 'done' stage is defined in the API, but not in the Product designs
     },
     charts: {
         primary: '#000080',

--- a/src/js/services/format.js
+++ b/src/js/services/format.js
@@ -66,4 +66,22 @@ export const github = {
     repoOrg: fullName => fullName.split('/')[1],
     repoName: fullName => fullName.split('/')[2],
     userName: fullName => fullName.split('/')[1],
+    prLink: (repoUrl, number) => `https://${repoUrl}/pull/${number}`,
+};
+
+const KILO = 1000;
+const MEGA = 1000 * KILO;
+
+export const number = {
+    si: n => {
+        if (n < KILO) {
+            return n;
+        } else if (n < MEGA) {
+            return (Math.round(n * 10 / KILO) / 10) + 'K';
+        } else if (n < 500 * MEGA) {
+            return (Math.round(n * 10 / MEGA) / 10) + 'M';
+        }
+
+        return '>500M';
+    }
 };

--- a/src/sass/_typography.scss
+++ b/src/sass/_typography.scss
@@ -1,1 +1,39 @@
 @import url('https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i&display=swap');
+
+@import "~@fortawesome/fontawesome-free/scss/fontawesome.scss";
+@import "~@fortawesome/fontawesome-free/scss/solid.scss";
+@import "~@fortawesome/fontawesome-free/scss/regular.scss";
+
+.text-merge {
+    color: $color-merge;
+}
+
+.fa {
+    @extend %fa-icon;
+
+    &.fas {
+        @extend .fas;
+    }
+
+    &.far {
+        @extend .far;
+    }
+
+    &:before {
+        margin-right: 5px;
+    }
+
+    &.fa-file-alt:before {
+        content: fa-content($fa-var-file-alt);
+    }
+
+    &.fa-comment-alt:before {
+        content: fa-content($fa-var-comment-alt);
+    }
+
+    &.fa-code-branch:before {
+        content: fa-content($fa-var-code-branch);
+        margin-right: 0;
+        transform: rotate(180deg);
+    }
+}

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -1,1 +1,3 @@
-$at-main-bg: #f5f5f5
+$at-main-bg: #f5f5f5;
+
+$color-merge: #9060E2;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -95,3 +95,79 @@ a {
         }
     }
 }
+
+#dataTable {
+    border-spacing: 0 3px !important;
+    border: 0 !important;
+
+    thead {
+        background-color: $secondary !important;
+
+        th {
+            @extend .text-xs;
+            @extend .text-uppercase;
+            @extend .font-weight-bold;
+            transform: translateY(2px);
+            border: 0;
+        }
+    }
+
+    td {
+        border-width: 1px 0 !important;
+        background-color: white;
+
+        &:last-child {
+            border-right-width: 1px !important;
+        }
+
+        &:first-child {
+            border-left-width: 1px !important;
+        }
+    }
+
+    .pr-size,
+    .pr-age {
+        white-space: nowrap;
+    }
+
+    td.pr-merged {
+        vertical-align: middle;
+        padding-left: 1rem;
+        padding-right: .25rem;
+    }
+
+    th.pr-merged {
+        padding-right: 0 !important;
+    }
+
+    $mainAvatarSize: 25px;
+    .pr-user-avatar {
+        display: inline-block;
+        border-radius: $mainAvatarSize;
+        width: $mainAvatarSize;
+        height: $mainAvatarSize;
+        margin-right: -.4 * $mainAvatarSize;
+        border: 2px solid white;
+        vertical-align: text-top;
+        cursor: default;
+
+        &.pr-user-unknown {
+            line-height: $mainAvatarSize;
+            background: #AAA;
+            text-align: center;
+            color: white;
+        }
+    }
+
+    $smallAvatarSize: 25px;
+    .pr-main .pr-user-avatar {
+        width: $smallAvatarSize;
+        height: $smallAvatarSize;
+        line-height: $smallAvatarSize;
+        margin-right: -.4 * $smallAvatarSize;
+
+        &+.pr-created-by {
+            margin-left: .4 * $smallAvatarSize;
+        }
+    }
+}


### PR DESCRIPTION
depends on https://github.com/athenianco/athenian-webapp/pull/60
depends on https://github.com/athenianco/athenian-webapp/pull/65
depends on https://github.com/athenianco/athenian-webapp/pull/66

This PR integrates the PRs from the context into the PRs table in the overview section.
The PR table lets the user to paginate, sort columns and filter by participants, stage, PR status...

It is only needed to review 467941d (the rest of the commits, are in the PRs listed above)

![image](https://user-images.githubusercontent.com/2437584/75129313-b5193f00-56c8-11ea-976e-e9c63439ed39.png)
