### PR TITLE
Refactoring sizes for spacers and type sizes to make it more intuitive

### DIFF
--- a/src/js/components/layout/Breadcrumbs.jsx
+++ b/src/js/components/layout/Breadcrumbs.jsx
@@ -7,7 +7,7 @@ export default ({ breadcrumbs }) => breadcrumbs && (
             <ol id="mainBreadcrumbs" className="breadcrumb bg-white mb-0 py-0 p-0" aria-label="breadcrumb">
                 {breadcrumbs.ancestors && breadcrumbs.ancestors.map((link, i) => (
                     <li key={i} className="breadcrumb-item text-xs">
-                        <Link to={link.url} className="text-secondary">{link.text}</Link>
+                        <Link to={link.url} className="text-bright">{link.text}</Link>
                     </li>
                 ))}
                 <li className="breadcrumb-item active" aria-current="page">{breadcrumbs.current}</li>

--- a/src/js/components/layout/Navbar.jsx
+++ b/src/js/components/layout/Navbar.jsx
@@ -31,8 +31,8 @@ const User = ({ user }) => {
           <header className="menuItem d-flex flex-row align-items-center bg-light py-2 border-bottom">
             <img className="img-profile rounded-circle" alt="" src={user.picture || defaultImage} />
             <div className="userData">
-              <p className="mb-1 text-truncate font-weight-bold text-gray-900">{user.name}</p>
-              <p className="mb-0 text-truncate">{user.email}</p>
+              <p className="mb-0 text-truncate font-weight-bold text-gray-900">{user.name}</p>
+              <p className="mb-0 text-truncate text-xs">{user.email}</p>
             </div>
           </header>
           <InvitationCreator user={user} className="menuItem py-3" />

--- a/src/sass/_overrides.scss
+++ b/src/sass/_overrides.scss
@@ -40,7 +40,7 @@ $font-family-sans-serif: 'Cerebri', -apple-system, BlinkMacSystemFont, "Segoe UI
 
 // Override Font sizes
 
-$font-size-base:              .875rem !default; // Assumes the browser default, typically `16px`
+$font-size-base:              1.2rem !default; // Assumes the browser default, typically `16px`
 $font-size-lg:                $font-size-base * 1.25 !default;
 $font-size-sm:                $font-size-base * .75 !default;
 
@@ -57,6 +57,7 @@ $theme-colors: (
         "warning": #FFC508,
         "info": #147EEC,
         "light": #FAFAFB,
+        "bright": rgba(#8889A1, .5),
         "dark": #121343
 );
 
@@ -69,3 +70,21 @@ $colors: (
         "yellow": #FFC508,
         "green": #2FCC71
 );
+
+// Spacing
+
+$spacer: 0.1rem !default;
+$spacers: (
+    0: 0,
+    1: ($spacer * 5),
+    2: ($spacer * 10),
+    3: ($spacer * 15),
+    4: ($spacer * 20),
+    5: ($spacer * 30),
+    6: ($spacer * 60),
+
+    // Specific pixel spacers
+
+    12: ($spacer * 12),
+    24: ($spacer * 24)
+)

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -20,6 +20,10 @@
     font-weight: 700;
 }
 
+html {
+    font-size: 62.5%;
+}
+
 .text-merge {
     color: $color-merge;
 }
@@ -56,4 +60,12 @@
         margin-right: 0;
         transform: rotate(180deg);
     }
+}
+
+.text-xs {
+    font-size: 1.1rem !important;
+}
+
+.text-lg {
+    font-size: 2.1rem !important;
 }

--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -1,12 +1,11 @@
 .badge {
-    border-radius: .2rem !important;
-    padding: .3rem .5rem !important;
-    -webkit-padding-before: .35rem !important;
+    border-radius: .4rem !important;
+    font-size: 1.1rem !important;
+    padding: .5rem .8rem !important;
 
     &.badge-pill {
-        border-radius: .5rem !important;
-        padding: .15rem .5rem !important;
-        -webkit-padding-before: .25rem !important;
+        border-radius: 2rem !important;
+        padding: .3rem .8rem !important;
     }
 
     &.badge-danger {
@@ -30,11 +29,11 @@
         background: transparent;
         border: 1px solid;
         text-transform: uppercase;
-        font-size: 0.7rem;
+        font-size: 1.1rem;
         font-weight: 400;
         padding: .4rem 1rem !important;
         min-width: 100px;
-        line-height: 1rem;
+        line-height: 1.8rem;
 
         &.badge-primary {
             border-color: $primary;

--- a/src/sass/components/_dropdowns.scss
+++ b/src/sass/components/_dropdowns.scss
@@ -1,6 +1,6 @@
 .navbar-nav .dropdown .dropdown-menu {
-    $menuWidth: 19rem;
-    $menuImageWidth: 4rem;
+    $menuWidth: 30rem;
+    $menuImageWidth: 6rem;
     $menuHorizontalPadding: map-get($spacers, 3);
     $menuUserLeftMargin: map-get($spacers, 2);
 
@@ -14,6 +14,7 @@
     .userData {
         width: $menuWidth - $menuImageWidth - 2 * $menuHorizontalPadding - $menuUserLeftMargin;
         margin-left: $menuUserLeftMargin;
+        font-size: 1.5rem;
     }
 
     .menuItem {
@@ -34,4 +35,9 @@
             width: $copyButtonWidth;
         }
     }
+}
+
+.topbar .nav-item .nav-link .img-profile {
+    height: 3rem !important;
+    width: 3rem !important;
 }

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -1,5 +1,10 @@
 .table {
     color: $secondary;
+
+    th,
+    td {
+        padding: 1rem !important;
+    }
 }
 
 #dataTable {
@@ -80,7 +85,7 @@
     }
 
     td.pr-age {
-        font-size: .65rem;
+        font-size: 1.1rem;
     }
 
     td.pr-participants,
@@ -141,7 +146,7 @@
     }
 
     .table-title {
-        font-size: .9rem;
+        font-size: 1.4rem;
         font-weight: 400;
         max-width: 500px;
         text-overflow: ellipsis;
@@ -150,7 +155,7 @@
     }
 
     .table-creators {
-        font-size: .65rem;
+        font-size: 1rem;
 
         * {
             display: inline-block;

--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -2,8 +2,9 @@
     height: 24px;
 }
 
-.topbar.navbar {
-    height: 48px;
+.navbar {
+    height: 42px;
+    padding: 0;
 }
 
 #mainBreadcrumbs {
@@ -11,5 +12,9 @@
 
     li {
         display: inline-block;
+
+        &.active {
+            font-size: 1.5rem;
+        }
     }
 }


### PR DESCRIPTION
This PR is related to the task [#ENG-276](https://athenianco.atlassian.net/jira/software/projects/ENG/boards/4?assignee=5e57d3bc459a810c9af2098b&selectedIssue=ENG-276). I refactored the sizing of all spacer elements and typography sizes to make it more intuitive to work according to the pixel sizes on the prototypes and the rem units, refactoring everything to make `1rem = 10px`.

I added new custom spacer sizes and fixed some minor issues after the refactor to keep it looking as it was previously.

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>