### PR TITLE
Persist the current API schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-src/js/services/api/openapi.*.yaml
-
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/src/js/services/api/openapi.v0.0.39.yaml
+++ b/src/js/services/api/openapi.v0.0.39.yaml
@@ -1,0 +1,1428 @@
+openapi: 3.0.3
+info:
+  description: "Server version: {{ server_version }} built on {{ build_date }} @ {{ commit }}"
+  contact:
+    name: the admins by email
+    email: admin@athenian.co
+  license:
+    name: CC-BY-4.0
+  title: "{{ title }}"
+  version: 1.0.0
+servers:
+- url: "{{ server_url }}/v1"
+  description: "{{ server_description }} - {{ server_url }}"
+paths:
+  /account/{id}:
+    get:
+      operationId: get_account
+      parameters:
+      - description: Numeric identifier of the account to list. The user must belong
+          to that account. To find out which accounts the user belongs to, see `/user`.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          description: List the current user's account members.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user does not have access to this account.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The account was not found.
+      security:
+      - bearerAuth: []
+      summary: List the current user's account members.
+      tags:
+      - user
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.user_controller
+      x-codegen-request-body-name: body
+  /become:
+    get:
+      operationId: become_user
+      parameters:
+      - description: Numeric identifier of the user to turn into.
+        explode: false
+        in: query
+        name: id
+        required: false
+        schema:
+          type: string
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: Details of the new active user, the same as `/user`.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Current user is not allowed to mutate.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Requested user does not exist.
+      security:
+      - bearerAuth: []
+      summary: \"God mode\" ability to turn into any user. The current user must be
+        marked internally as a super admin.
+      tags:
+      - user
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.user_controller
+      x-codegen-request-body-name: body
+  /filter/contributors:
+    post:
+      operationId: filter_contributors
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilterItemsRequest'
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeveloperSet'
+          description: Repositories that were updated within the given timeframe.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Current user is not allowed to access the specified account.
+      security:
+      - bearerAuth: []
+      summary: Find developers that made an action within the given timeframe.
+      tags:
+      - filter
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.filter_controller
+      x-codegen-request-body-name: body
+  /filter/pull_requests:
+    post:
+      operationId: filter_prs
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilterPullRequestsRequest'
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PullRequestSet'
+          description: List of pull requests satisfying the specified filters.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Current user is not allowed to access the specified account
+            or reposets.
+      security:
+      - bearerAuth: []
+      summary: List pull requests that satisfy the query.
+      tags:
+      - filter
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.filter_controller
+  /filter/repositories:
+    post:
+      operationId: filter_repositories
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilterItemsRequest'
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositorySet'
+          description: Repositories that were updated within the given timeframe.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Current user is not allowed to access the specified account
+            or reposets.
+      security:
+      - bearerAuth: []
+      summary: Find repositories that were updated within the given timeframe.
+      tags:
+      - filter
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.filter_controller
+      x-codegen-request-body-name: body
+  /invite/accept:
+    put:
+      operationId: accept_invitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvitationLink'
+        description: Accepted invitation details.
+        required: true
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitedUser'
+          description: Details about the new user.
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Something is wrong with the invitation URL.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Invitation was disabled.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: Invitation was not found.
+      security:
+      - bearerAuth: []
+      summary: Accept the account membership invitation and finish registration. The
+        user must be already authorized in Auth0.
+      tags:
+      - registration
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.invitation_controller
+      x-codegen-request-body-name: body
+  /invite/check:
+    post:
+      operationId: check_invitation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvitationLink'
+        description: Checked invitation details.
+        required: true
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitationCheckResult'
+          description: 'Result of checking an invitation URL: invitation type, whether
+            it is correctly formed and is enabled.'
+      summary: Given an invitation URL, get its type (admin or regular account member)
+        and find whether it is correctly formed and is enabled or disabled.
+      tags:
+      - registration
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.invitation_controller
+      x-codegen-request-body-name: body
+  /invite/generate/{id}:
+    get:
+      operationId: gen_invitation
+      parameters:
+      - description: Numeric identifier of the account where to invite new users.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvitationLink'
+          description: The invitation link has been generated successfully.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user is forbidden to invite for this account.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The account was not found.
+      security:
+      - bearerAuth: []
+      summary: Generate an account invitation link for regular users. The caller must
+        be an admin of the specified account.
+      tags:
+      - registration
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.invitation_controller
+      x-codegen-request-body-name: body
+  /metrics_line:
+    post:
+      operationId: calc_metrics_line
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetricsRequest'
+        description: Desired metric definitions.
+        required: true
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CalculatedMetrics'
+          description: Calculated metrics.
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvalidRequestError'
+          description: The request was invalid.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user is forbidden to calculate metrics on behalf of the
+            specified account.
+        422:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSourceDataError'
+          description: No data is available to calculate metrics for the given repositories.
+      security:
+      - bearerAuth: []
+      summary: Calculate metrics.
+      tags:
+      - metrics
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.metrics_controller
+      x-codegen-request-body-name: body
+  /reposet/create:
+    post:
+      operationId: create_reposet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepositorySetCreateRequest'
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatedIdentifier'
+          description: Identifier of the created repository set.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user is forbidden to create a repository set from the specified
+            items.
+      security:
+      - bearerAuth: []
+      summary: Create a repository set.
+      tags:
+      - reposet
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.reposet_controller
+      x-codegen-request-body-name: body
+  /reposet/{id}:
+    delete:
+      operationId: delete_reposet
+      parameters:
+      - description: Numeric identifier of the repository set to list.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Empty object indicates a successful removal.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user is forbidden to delete the specified repository set.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The specified repository set was not found.
+      security:
+      - bearerAuth: []
+      summary: Delete a repository set. The user must be an admin of the account that
+        owns the reposet.
+      tags:
+      - reposet
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.reposet_controller
+      x-codegen-request-body-name: body
+    get:
+      operationId: get_reposet
+      parameters:
+      - description: Numeric identifier of the repository set to list.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositorySet'
+          description: List of repositories in the specified set.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user is forbidden to list the specified repository set.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The specified repository set was not found.
+      security:
+      - bearerAuth: []
+      summary: List a repository set. The user must be in the account that owns the
+        reposet.
+      tags:
+      - reposet
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.reposet_controller
+      x-codegen-request-body-name: body
+    put:
+      operationId: update_reposet
+      parameters:
+      - description: Numeric identifier of the repository set to list.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+        style: simple
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RepositorySet'
+        x-body-name: body
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Empty object indicates a successful operation.
+        403:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user is forbidden to update the specified repository set.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The specified repository set was not found.
+      security:
+      - bearerAuth: []
+      summary: Update a repository set. The user must be an admin of the account that
+        owns the reposet.
+      tags:
+      - reposet
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.reposet_controller
+      x-codegen-request-body-name: body
+  /reposets/{id}:
+    get:
+      operationId: list_reposets
+      parameters:
+      - description: Numeric identifier of the account.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RepositorySetList'
+          description: List the repository sets belonging to the specified account.
+        404:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericError'
+          description: The user does not belong to the specified account.
+      security:
+      - bearerAuth: []
+      summary: List the repository sets belonging to the current user.
+      tags:
+      - reposet
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.reposet_controller
+      x-codegen-request-body-name: body
+  /user:
+    get:
+      operationId: get_user
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: Details about the current user.
+      security:
+      - bearerAuth: []
+      summary: Show details about the current user.
+      tags:
+      - user
+# {% if False %}
+      - default
+# {% endif %}
+      x-openapi-router-controller: athenian.api.controllers.user_controller
+      x-codegen-request-body-name: body
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      x-bearerInfoFunc: athenian.api.controllers.security_controller.info_from_bearerAuth
+  schemas:
+    CreatedIdentifier:
+      example:
+        id: 777
+      properties:
+        id:
+          description: Identifier of the created entity.
+          example: 777
+          type: integer
+      required:
+      - id
+      type: object
+    GenericError:
+      properties:
+        type:
+          description: URI reference that identifies the problem type (RFC 7807).
+          example: /errors/metrics_line/InvalidRequestError
+          type: string
+        title:
+          description: Short, human-readable summary of the problem type.
+          example: Validation failed
+          type: string
+        status:
+          description: Duplicated HTTP status code.
+          example: 400
+          type: integer
+        detail:
+          description: Human-readable explanation specific to this occurrence of the
+            problem.
+          example: '"pr-slave-time" is not one of [...].'
+          type: string
+        instance:
+          description: URI reference that identifies the specific occurrence of the
+            problem.
+          example: https://sentry.io/athenian/api/?query=2763c4eabd7240f59829ee1a02546293
+          type: string
+      required:
+      - title
+      - type
+      type: object
+    InvalidRequestError:
+      allOf:
+      - $ref: '#/components/schemas/GenericError'
+      - type: object
+        properties:
+          pointer:
+            description: Path to the offending request item.
+            example: .granularity
+            type: string
+    NoSourceDataError:
+      allOf:
+      - $ref: '#/components/schemas/GenericError'
+      - type: object
+        properties:
+          repositories:
+            $ref: '#/components/schemas/RepositorySet'
+    MetricID:
+      description: Currently supported metric types.
+      enum:
+      - pr-wip-time
+      - pr-review-time
+      - pr-merging-time
+      - pr-release-time
+      - pr-lead-time
+      - pr-flow-ratio
+      - pr-opened
+      - pr-merged
+      - pr-closed
+      - pr-wait-first-review
+      example: pr-lead-time
+      type: string
+    DeveloperID:
+      description: |
+        User name which uniquely identifies any developer on any service provider.
+        The format matches the profile URL without the protocol part.
+      example: github.com/vmarkovtsev
+      type: string
+    RepositoryID:
+      description: |
+        Repository name which uniquely identifies any repository in any service provider.
+        The format matches the repository URL without the protocol part. No ".git" should be appended.
+        We support a special syntax for repository sets: "{reposet id}" adds all the repositories
+        from the given set.
+      example: github.com/src-d/go-git
+      type: string
+    DeveloperSet:
+      description: A set of developers. An empty list disables the filter and includes
+        everybody. Duplicates are automatically ignored.
+      example:
+      - github.com/vmarkovtsev
+      - github.com/mcuadros
+      items:
+        $ref: '#/components/schemas/DeveloperID'
+      type: array
+    RepositorySet:
+      description: A set of repositories. An empty list results an empty response
+        in contrary to DeveloperSet. Duplicates are automatically ignored.
+      example:
+      - github.com/src-d/hercules
+      - github.com/athenianco/athenian-api
+      items:
+        $ref: '#/components/schemas/RepositoryID'
+      type: array
+    RepositorySetList:
+      description: List of repository sets owned by a user.
+      items:
+        $ref: '#/components/schemas/RepositorySetListItem'
+      type: array
+    RepositorySetCreateRequest:
+      description: Repository set creation request.
+      example:
+        account: 1
+        items:
+        - github.com/src-d/hercules
+        - github.com/athenianco/athenian-api
+      properties:
+        account:
+          description: Account identifier. That account will own the created repository
+            set. The user must be an admin of the account.
+          type: integer
+        items:
+          $ref: '#/components/schemas/RepositorySet'
+      required:
+      - account
+      - items
+      type: object
+    RepositorySetListItem:
+      description: Element of RepositorySetList.
+      example:
+        items_count: 6
+        created: 2020-01-23T04:56:07.000+00:00
+        id: 1
+        updated: 2020-01-23T04:56:07.000+00:00
+      properties:
+        id:
+          description: Repository set identifier.
+          type: integer
+        created:
+          description: Date and time of creation of the repository set.
+          format: date-time
+          type: string
+        updated:
+          description: Date and time of the last change of the repository set.
+          format: date-time
+          type: string
+        items_count:
+          description: Number of repositories in the set.
+          type: integer
+      type: object
+    User:
+      description: User details. "updated" and "accounts" are populated only for the
+        current user.
+      example:
+        id: github|60340680
+        native_id: 60340680
+        name: Groundskeeper Willie
+        email: bot@athenian.co
+        picture: https://avatars0.githubusercontent.com/u/60340680?v=4
+        updated: 2020-01-23T12:00:00Z
+      properties:
+        id:
+          description: Auth0 user identifier.
+          type: string
+        native_id:
+          description: Auth backend user identifier.
+          type: string
+        name:
+          description: Full name of the user.
+          type: string
+        email:
+          description: Email of the user.
+          type: string
+        picture:
+          description: Avatar URL of the user.
+          type: string
+        updated:
+          description: Date and time of the last profile update.
+          format: date-time
+          type: string
+        accounts:
+          description: Mapping between account IDs the user is a member of and is_admin
+            flags.
+          example:
+            1: true
+            2: false
+          type: object
+      required:
+      - email
+      - id
+      - name
+      - native_id
+      - picture
+      type: object
+    InvitedUser:
+      description: Details about the user who has accepted an invitation.
+      example:
+        user:
+          id: github|60340680
+          native_id: 60340680
+          name: Groundskeeper Willie
+          email: bot@athenian.co
+          picture: https://avatars0.githubusercontent.com/u/60340680?v=4
+          updated: 2020-01-23T12:00:00Z
+        account: 0
+      properties:
+        account:
+          description: Joined account ID.
+          type: integer
+        user:
+          $ref: '#/components/schemas/User'
+      required:
+      - account
+      - user
+      type: object
+    Account:
+      description: Account members. "updated" and "accounts" are not populated.
+      example:
+        regulars:
+        - id: 248289761001
+          name: Jane Josephine Doe
+          email: janedoe@exampleco.com
+          picture: http://exampleco.com/janedoe/me.jpg
+          updated: 2020-01-23T12:00:00Z
+        - id: 248289761001
+          name: Jane Josephine Doe
+          email: janedoe@exampleco.com
+          picture: http://exampleco.com/janedoe/me.jpg
+          updated: 2020-01-23T12:00:00Z
+        admins:
+        - id: 248289761001
+          name: Jane Josephine Doe
+          email: janedoe@exampleco.com
+          picture: http://exampleco.com/janedoe/me.jpg
+          updated: 2020-01-23T12:00:00Z
+        - id: 248289761001
+          name: Jane Josephine Doe
+          email: janedoe@exampleco.com
+          picture: http://exampleco.com/janedoe/me.jpg
+          updated: 2020-01-23T12:00:00Z
+      properties:
+        admins:
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+        regulars:
+          items:
+            $ref: '#/components/schemas/User'
+          type: array
+      required:
+      - admins
+      - regulars
+      type: object
+    InvitationLink:
+      example:
+        url: https://app.athenian.co/i/deadf88d
+      properties:
+        url:
+          description: Invitation URL. Users are supposed to click it and become admins
+            or regular account members.
+          format: url
+          type: string
+      required:
+      - url
+      type: object
+    InvitationCheckResult:
+      example:
+        active: true
+        type: regular
+        valid: true
+      properties:
+        active:
+          description: Value indicating whether the invitation is still enabled.
+          type: boolean
+        type:
+          description: Invited user's account membership status.
+          enum:
+          - admin
+          - regular
+          type: string
+        valid:
+          description: Value indicating whether the invitation URL is correctly formed.
+          type: boolean
+      required:
+      - valid
+      type: object
+    ForSet:
+      example:
+        repositories:
+        - github.com/src-d/hercules
+        - github.com/athenianco/athenian-api
+        developers:
+        - github.com/vmarkovtsev
+        - github.com/mcuadros
+      properties:
+        repositories:
+          $ref: '#/components/schemas/RepositorySet'
+        developers:
+          $ref: '#/components/schemas/DeveloperSet'
+      required:
+      - repositories
+      type: object
+    Granularity:
+      description: 'How often the metrics are reported. The value must satisfy the
+        following regular expression: (^([1-9]\d* )?(day|week|month|year)$'
+      example: 2 week
+      type: string
+    MetricsRequest:
+      example:
+        for:
+        - repositories:
+          - github.com/src-d/hercules
+          - github.com/athenianco/athenian-api
+          developers:
+          - github.com/vmarkovtsev
+          - github.com/mcuadros
+        - repositories:
+          - github.com/src-d/hercules
+          - github.com/athenianco/athenian-api
+          developers:
+          - github.com/vmarkovtsev
+          - github.com/mcuadros
+        metrics:
+        - pr-lead-time
+        - pr-wip-time
+        date_from: 2000-01-23
+        date_to: 2020-01-23
+        granularity: day
+        account: 1
+      properties:
+        for:
+          description: Sets of developers and repositories to calculate the metrics
+            for.
+          items:
+            $ref: '#/components/schemas/ForSet'
+          type: array
+        metrics:
+          description: Requested metric identifiers.
+          items:
+            $ref: '#/components/schemas/MetricID'
+          type: array
+        date_from:
+          description: Date from when to start measuring the metrics.
+          format: date
+          type: string
+        date_to:
+          description: Date up to which to measure the metrics.
+          format: date
+          type: string
+        granularity:
+          $ref: '#/components/schemas/Granularity'
+        account:
+          description: Session account ID.
+          type: integer
+      required:
+      - account
+      - date_from
+      - date_to
+      - for
+      - granularity
+      - metrics
+      type: object
+    CalculatedMetric:
+      example:
+        values:
+        - date: 2000-01-23
+          values:
+          - 0.8008282
+          - 0.8008282
+          confidence_mins:
+          - 0.5
+          - 0.5
+          confidence_maxs:
+          - 1.0
+          - 1.0
+          confidence_scores:
+          - 75
+          - 75
+        - date: 2000-01-23
+          values:
+          - 0.8008282
+          - 0.8008282
+          confidence_mins:
+          - 0.5
+          - 0.5
+          confidence_maxs:
+          - 1.0
+          - 1.0
+          confidence_scores:
+          - 75
+          - 75
+        for:
+          repositories:
+          - github.com/src-d/hercules
+          - github.com/athenianco/athenian-api
+          developers:
+          - github.com/vmarkovtsev
+          - github.com/mcuadros
+      properties:
+        for:
+          $ref: '#/components/schemas/ForSet'
+        values:
+          items:
+            $ref: '#/components/schemas/CalculatedMetric_values'
+          type: array
+      required:
+      - for
+      - values
+      type: object
+    CalculatedMetrics:
+      example:
+        metrics:
+        - pr-lead-time
+        - pr-wip-time
+        date_from: 2000-01-23
+        granularity: day
+        calculated:
+        - values:
+          - date: 2000-01-23
+            values:
+            - 0.8008282
+            - 0.8008282
+            confidence_mins:
+            - 0.5
+            - 0.5
+            confidence_maxs:
+            - 1.0
+            - 1.0
+            confidence_scores:
+            - 75
+            - 75
+          - date: 2000-01-23
+            values:
+            - 0.8008282
+            - 0.8008282
+            confidence_mins:
+            - 0.5
+            - 0.5
+            confidence_maxs:
+            - 1.0
+            - 1.0
+            confidence_scores:
+            - 75
+            - 75
+          for:
+            developers:
+            - github.com/vmarkovtsev
+            - github.com/mcuadros
+            repositories:
+            - github.com/src-d/hercules
+            - github.com/athenianco/athenian-api
+        - values:
+          - date: 2000-01-23
+            values:
+            - 0.8008282
+            - 0.8008282
+            confidence_mins:
+            - 0.5
+            - 0.5
+            confidence_maxs:
+            - 1.0
+            - 1.0
+            confidence_scores:
+            - 75
+            - 75
+          - date: 2000-01-23
+            values:
+            - 0.8008282
+            - 0.8008282
+            confidence_mins:
+            - 0.5
+            - 0.5
+            confidence_maxs:
+            - 1.0
+            - 1.0
+            confidence_scores:
+            - 75
+            - 75
+          for:
+            developers:
+            - github.com/vmarkovtsev
+            - github.com/mcuadros
+            repositories:
+            - github.com/src-d/hercules
+            - github.com/athenianco/athenian-api
+        date_to: 2020-01-23
+      properties:
+        calculated:
+          description: The values of the requested metrics through time. The sequence
+            order is not guaranteed to be the same as in the preceding request.
+          items:
+            $ref: '#/components/schemas/CalculatedMetric'
+          type: array
+        metrics:
+          description: Repeats `MetricsRequest.metrics`.
+          items:
+            $ref: '#/components/schemas/MetricID'
+          type: array
+        date_from:
+          description: Repeats `MetricsRequest.date_from`.
+          format: date
+          type: string
+        date_to:
+          description: Repeats `MetricsRequest.date_to`.
+          format: date
+          type: string
+        granularity:
+          $ref: '#/components/schemas/Granularity'
+      required:
+      - calculated
+      - date_from
+      - date_to
+      - granularity
+      - metrics
+      type: object
+    CalculatedMetric_values:
+      example:
+        date: 2000-01-23
+        values:
+        - 0.8008282
+        - 0.8008282
+        confidence_mins:
+        - 0.5
+        - 0.5
+        confidence_maxs:
+        - 1.0
+        - 1.0
+        confidence_scores:
+        - 75
+        - 75
+      properties:
+        date:
+          description: Where you should relate the metric value to on the time axis.
+          format: date
+          type: string
+        values:
+          description: The same order as `metrics`.
+          items:
+            format: float
+            type: number
+          type: array
+        confidence_mins:
+          description: Confidence interval @ p=0.95, minimum. The same order as `metrics`.
+            It is optional because there can be exact metrics like "count open PRs
+            per month".
+          items:
+            format: float
+            type: number
+          type: array
+        confidence_maxs:
+          description: Confidence interval @ p=0.95, maximum. The same order as `metrics`.
+            It is optional because there can be exact metrics like "count open PRs
+            per month".
+          items:
+            format: float
+            type: number
+          type: array
+        confidence_scores:
+          description: Confidence score from 0 (no idea) to 100 (very confident).
+            The same order as `metrics`.
+          items:
+            type: integer
+          type: array
+      required:
+      - confidence_scores
+      - date
+      - values
+    FilterItemsRequest:
+      description: PR filters for /filter/contributors and /filter/repositories.
+      example:
+        account: 1
+        date_from: 2000-01-23
+        date_to: 2020-05-23
+        in:
+        - '{1}'
+      properties:
+        account:
+          description: Session account ID.
+          type: integer
+        date_from:
+          description: Updates must be later than or equal to this date. An update
+            is any action that influences the stage assignment.
+          format: date
+          type: string
+        date_to:
+          description: Updates must be earlier than or equal to this date. An update
+            is any action that influences the stage assignment.
+          format: date
+          type: string
+        in:
+          $ref: '#/components/schemas/RepositorySet'
+      required:
+      - account
+      - date_from
+      - date_to
+      type: object
+    FilterPullRequestsRequest:
+      description: Filters for /filter/pull_requests.
+      example:
+        account: 1
+        date_from: 2000-01-23
+        date_to: 2020-05-23
+        in:
+        - '{1}'
+        stages:
+        - wip
+        with:
+          author:
+          - github.com/vmarkovtsev
+      properties:
+        account:
+          description: Session account ID.
+          type: integer
+        date_from:
+          description: PRs must be updated later than or equal to this date.
+          format: date
+          type: string
+        date_to:
+          description: PRs must be updated earlier than or equal to this date.
+          format: date
+          type: string
+        in:
+          $ref: '#/components/schemas/RepositorySet'
+        stages:
+          items:
+            $ref: '#/components/schemas/PullRequestPipelineStage'
+          type: array
+        with:
+          $ref: '#/components/schemas/PullRequestWith'
+      required:
+      - account
+      - date_from
+      - date_to
+      type: object
+    PullRequestPipelineStage:
+      description: One of the four possible PR states of the modelled lifecycle.
+      enum:
+      - wip
+      - review
+      - merge
+      - release
+      - done  # PR afterlife - PRs that were released and nothing ever happens to them
+      example: wip
+      type: string
+    PullRequestSet:
+      description: List of pull requests together with the participant profile pictures.
+      example:
+        include:
+          users:
+            key:
+              avatar: https://avatars0.githubusercontent.com/u/60340680?v=4
+        data:
+        - repository: github.com/src-d/go-git
+          number: 1152
+          title: 'Fix an edge case when fetching remotes with unrelated incomplete
+            history. Fixes #1151'
+          size_added: 37
+          size_removed: 1
+          files_changed: 2
+          created: 2019-05-17T01:14:00Z
+          updated: 2019-09-18T10:49:00Z
+          stage: wip
+          participants:
+          - id: github.com/NonLogicalDev
+            status: author
+          - id: github.com/mcuadros
+            status: commenter
+      properties:
+        include:
+          $ref: '#/components/schemas/PullRequestSet_include'
+        data:
+          description: List of matched pull requests.
+          items:
+            $ref: '#/components/schemas/PullRequest'
+          type: array
+      required:
+      - data
+      - include
+      type: object
+    PullRequestSet_include_user:
+      description: User traits such as the avatar URL.
+      example:
+        avatar: https://avatars0.githubusercontent.com/u/60340680?v=4
+      properties:
+        avatar:
+          format: url
+          type: string
+      required:
+      - avatar
+    PullRequestSet_include:
+      example:
+        users:
+          github.com/gkwillie:
+            avatar: https://avatars0.githubusercontent.com/u/60340680?v=4
+      properties:
+        users:
+          additionalProperties:
+            $ref: '#/components/schemas/PullRequestSet_include_user'
+          description: Mapping user login -> user details. The users are mentioned
+            in PRs in "PullRequestSet.data".
+          type: object
+      required:
+      - users
+    PullRequest:
+      description: Details of a pull request.
+      example:
+        # https://github.com/src-d/go-git/pull/1152
+        repository: github.com/src-d/go-git
+        number: 1152
+        title: 'Fix an edge case when fetching remotes with unrelated incomplete history.
+          Fixes #1151'
+        size_added: 37
+        size_removed: 1
+        files_changed: 2
+        created: 2019-05-17T01:14:00Z
+        updated: 2019-09-18T10:49:00Z
+        closed: null
+        merged: false
+        comments: 1
+        commits: 2
+        review_comments: 0
+        review_requested: false
+        stage: wip
+        participants:
+        - id: github.com/NonLogicalDev
+          status: author
+        - id: github.com/mcuadros
+          status: commenter
+      properties:
+        repository:
+          description: PR is/was open in this repository.
+          type: string
+        number:
+          description: PR number.
+          type: integer
+        title:
+          description: Title of the PR.
+          type: string
+        size_added:
+          description: Overall number of lines added.
+          type: integer
+        size_removed:
+          description: Overall number of lines removed.
+          type: integer
+        files_changed:
+          description: Number of files changed in this PR.
+          type: integer
+        created:
+          description: When this PR was created.
+          format: date-time
+          type: string
+        updated:
+          description: When this PR was last updated.
+          format: date-time
+          type: string
+        closed:
+          description: When this PR was last closed.
+          format: date-time
+          nullable: true
+          type: string
+        comments:
+          description: Number of *regular* (not review) comments in this PR.
+          type: integer
+        commits:
+          description: Number of commits in this PR.
+          type: integer
+        review_requested:
+          description: Value indicating whether the author of this PR requested a review.
+          type: boolean
+        review_comments:
+          description: Number of review comments this PR received.
+          type: integer
+        merged:
+          description: Value indicating whether this PR was merged.
+          type: boolean
+        stage:
+          $ref: '#/components/schemas/PullRequestPipelineStage'
+        participants:
+          description: List of developers related to this PR, always including the
+            author.
+          items:
+            $ref: '#/components/schemas/PullRequestParticipant'
+          type: array
+      required:
+      - closed
+      - comments
+      - commits
+      - created
+      - files_changed
+      - merged
+      - number
+      - participants
+      - repository
+      - review_comments
+      - review_requested
+      - size_added
+      - size_removed
+      - stage
+      - title
+      - updated
+      type: object
+    PullRequestParticipant:
+      description: Developer and their role in the PR.
+      properties:
+        id:
+          description: Person identifier.
+          example: github.com/vmarkovtsev
+          type: string
+        status:
+          items:
+            enum:
+            - author
+            - reviewer
+            - commit_author
+            - commit_committer
+            - commenter
+            - merger
+            type: string
+          type: array
+      required:
+      - id
+      - status
+    PullRequestWith:
+      description: 'Triage PRs by various developer participation. The aggregation is OR between
+        the participation groups and OR within each group. For example, if our request is
+        {"author": ["github.com/vmarkovtsev"], "reviewer": ["github.com/gkwillie", "github.com/mcuadros"]}
+        then the matched PRs will have @vmarkovtsev as the author or either @gkwillie or @mcuadros
+        as the reviewers.'
+      example:
+        author:
+        - github.com/vmarkovtsev
+      properties:
+        author:
+          $ref: '#/components/schemas/DeveloperSet'
+        reviewer:
+          $ref: '#/components/schemas/DeveloperSet'
+        commit_author:
+          $ref: '#/components/schemas/DeveloperSet'
+        commit_committer:
+          $ref: '#/components/schemas/DeveloperSet'
+        commenter:
+          $ref: '#/components/schemas/DeveloperSet'
+        merger:
+          $ref: '#/components/schemas/DeveloperSet'
+      type: object


### PR DESCRIPTION
caused by https://github.com/athenianco/athenian-webapp/pull/75/files#r383942255

Once a new API schema is successfully used to autogenerate the API client, its sources will be stored into as 'src/js/services/api/openapi.v*.yaml' and the old ones will be removed.