### PR TITLE
Enhance debug experience on Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+MAKEFLAGS += --no-builtin-rules
+
 # Package configuration
 PROJECT = athenian-webapp
 SERVICE_NAME = web-app


### PR DESCRIPTION
Make is automatically checking built-in rules for every target it runs wich may cause uncontrolled issues if that Make feature is now known and used on purpose.
This feature can be disabled if running it with `-r` or adding it to the `MAKEFLAGS`.

Disabling this feature also helps when debugging a Makefile because there will be output way fewer rules (only the explicit ones, and no tons of the Make built-in ones)

read more at https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html