### PR TITLE
Fixing table sort icons

### DIFF
--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -60,7 +60,7 @@
             &.sorting_asc,
             &.sorting_desc {
                 color: $dark;
-                padding-left: 24px;
+                padding-left: 24px !important;
             }
         }
     }


### PR DESCRIPTION
This is the first task on the issue [#ENG-281](https://athenianco.atlassian.net/jira/software/projects/ENG/boards/4?assignee=5e57d3bc459a810c9af2098b&selectedIssue=ENG-281). It fixes the sorting icons on the PR tables:

![image](https://user-images.githubusercontent.com/14981468/75881143-d394de00-5e1e-11ea-9317-b1117ba2b3e3.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>