### PR TITLE
Adding fixed height to pipeline tabs

### DIFF
--- a/src/sass/components/_pipeline.scss
+++ b/src/sass/components/_pipeline.scss
@@ -12,6 +12,7 @@
 
     .card {
         border-radius: .35rem .35rem 0 0;
+        min-height: 122px;
     }
 
     .pipeline-stage {


### PR DESCRIPTION
This is a task from the issue [#ENG-281](https://athenianco.atlassian.net/jira/software/projects/ENG/boards/4?assignee=5e57d3bc459a810c9af2098b&selectedIssue=ENG-281)

I fixes a minor bug on the pipeline so now all elements will be aligned even when they don't have content.

![image](https://user-images.githubusercontent.com/14981468/75890812-29718200-5e2f-11ea-8093-e3002c846303.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>