### PR TITLE
Centered alignment of the PR tabs

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -190,7 +190,7 @@ export default ({ data }) => {
         <>
             <div className="row mb-4">
                 <div className="col-12">
-                    <div className="d-flex border-bottom">
+                    <div className="d-flex justify-content-center border-bottom">
                         <div className="pr-tab card mr-2 p-0 border-0 border-bottom-primary rounded-top rounded-0 rounded-top bg-transparent">
                             <div className="card-body px-0 py-3">
                                 <SmallTitle content="Pull Requests" isBlack />

--- a/src/sass/_overrides.scss
+++ b/src/sass/_overrides.scss
@@ -50,7 +50,7 @@ $font-size-sm:                $font-size-base * .75 !default;
 // Color variables
 
 $theme-colors: (
-        "primary": #FF7427,
+        "primary": #FFA008,
         "secondary": #8889A1,
         "success": #2FCC71,
         "danger": #EF3837,


### PR DESCRIPTION
This task is related to the issue [#ENG-281](https://athenianco.atlassian.net/jira/software/projects/ENG/boards/4?assignee=5e57d3bc459a810c9af2098b&selectedIssue=ENG-281)

I fixed the alignment of the PR tabs and also changed the highlight color to the proper light orange:

![image](https://user-images.githubusercontent.com/14981468/75891480-1f9c4e80-5e30-11ea-979c-aaab177f6ed3.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>