### PR TITLE
Adding style to the tooltips

### DIFF
--- a/src/sass/components/_tooltips.scss
+++ b/src/sass/components/_tooltips.scss
@@ -1,0 +1,17 @@
+.tooltip {
+
+    &.show {
+        opacity: 1 !important;
+    }
+
+    .tooltip-inner {
+        background: #121343;
+        border-radius: 0;
+        font-size: 1rem;
+        font-weight: 300;
+        max-width: 250px;
+        opacity: 1;
+        padding: 1.5rem;
+        text-align: left;
+    }
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -16,3 +16,4 @@
 @import 'components/pagination';
 @import 'components/pipeline';
 @import 'components/tables';
+@import 'components/tooltips';


### PR DESCRIPTION
This task is related to the issue [#ENG-281](https://athenianco.atlassian.net/jira/software/projects/ENG/boards/4?assignee=5e57d3bc459a810c9af2098b&selectedIssue=ENG-281).

It fixes the tooltips styles to make them match the prototypes

![image](https://user-images.githubusercontent.com/14981468/75902547-71e56b80-5e40-11ea-8979-7a592241eded.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>