### PR TITLE
Reorganizing color variables

### DIFF
--- a/src/js/components/layout/Navbar.jsx
+++ b/src/js/components/layout/Navbar.jsx
@@ -31,13 +31,13 @@ const User = ({ user }) => {
           <header className="menuItem d-flex flex-row align-items-center bg-light py-2 border-bottom">
             <img className="img-profile rounded-circle" alt="" src={user.picture || defaultImage} />
             <div className="userData">
-              <p className="mb-0 text-truncate font-weight-bold text-gray-900">{user.name}</p>
-              <p className="mb-0 text-truncate text-xs">{user.email}</p>
+              <p className="mb-0 text-truncate text-dark">{user.name}</p>
+              <p className="mb-0 text-truncate font-weight-light text-s">{user.email}</p>
             </div>
           </header>
           <InvitationCreator user={user} className="menuItem py-3" />
           <footer className="menuItem d-flex flex-row align-items-center justify-content-end bg-light py-2 text-xs border-top">
-            <Link to="/logout">Logout</Link>
+            <Link to="/logout" className="text-s text-secondary">Logout</Link>
           </footer>
         </form>
       </li>

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -53,8 +53,10 @@ export default ({ data }) => {
                     "<option value='40'>40</option>"+
                     "<option value='50'>50</option>"+
                     "<option value='-1'>All</option>"+
-                    "</select>"
-                },
+                    "</select>",
+                searchPlaceholder: "Search...",
+                search: "<i class='field-icon fas fa-search' aria-hidden='true'></i>"
+            },
             fixedHeader: true,
             data: prs,
             columns: [

--- a/src/js/components/ui/CopyButton.jsx
+++ b/src/js/components/ui/CopyButton.jsx
@@ -14,11 +14,11 @@ export default ({ content }) => {
             <button type="button" className="py-1 btn btn-outline-secondary">
                 {!copiedState ? (
                     <>
-                        <FontAwesomeIcon icon={faClone} className="mr-2 text-secondary text-gray-400" />
-                        copy
+                        <FontAwesomeIcon icon={faClone} className="mr-1 text-secondary" />
+                        <span className="d-inline-block">Copy</span>
                     </>
                 ) : (
-                        'copied'
+                        'Copied'
                     )}
             </button>
         </CopyToClipboard>

--- a/src/js/res/palette.js
+++ b/src/js/res/palette.js
@@ -14,7 +14,7 @@ export const palette = {
         review: '#FFC508',
         merge: '#9260E2',
         release: '#2FCC71',
-        done: 'red', // TODO (dpordomingo): 'done' stage is defined in the API, but not in the Product designs
+        done: '#24C7CC',
     },
     schemes: {
         primary: primary,

--- a/src/js/smart-components/InvitationCreator.jsx
+++ b/src/js/smart-components/InvitationCreator.jsx
@@ -38,9 +38,9 @@ export default ({ user, className }) => {
             </div>
         ) : (
                 urlState && (
-                    <div className={classnames('invitationCreator d-flex flex-row d-flex justify-content-between align-items-center text-xs', className)}>
+                    <div className={classnames('invitationCreator d-flex flex-row d-flex justify-content-between align-items-center font-weight-light text-s', className)}>
                         <div className="desc">
-                            <p className="my-0 text-truncate font-weight-bold text-gray-900">Invite</p>
+                            <p className="my-0 text-truncate text-dark">Invite</p>
                             <p className="my-0 text-truncate">{urlState}</p>
                         </div>
 

--- a/src/sass/_overrides.scss
+++ b/src/sass/_overrides.scss
@@ -50,25 +50,25 @@ $font-size-sm:                $font-size-base * .75 !default;
 // Color variables
 
 $theme-colors: (
-        "primary": #FFA008,
-        "secondary": #8889A1,
-        "success": #2FCC71,
-        "danger": #EF3837,
-        "warning": #FFC508,
-        "info": #147EEC,
-        "light": #FAFAFB,
-        "bright": rgba(#8889A1, .5),
-        "dark": #121343
+        "primary": $color-primary,
+        "secondary": $color-secondary,
+        "success": $color-success,
+        "danger": $color-danger,
+        "warning": $color-warning,
+        "info": $color-info,
+        "light": $color-light,
+        "bright": $color-bright,
+        "dark": $color-dark
 );
 
 $colors: (
-        "blue": #147EEC,
-        "purple": #9260E2,
-        "pink": #FC1763,
-        "red": #EF3837,
-        "orange": #FF7427,
-        "yellow": #FFC508,
-        "green": #2FCC71
+        "blue": $color-blue,
+        "purple": $color-purple,
+        "pink": $color-pink,
+        "red": $color-red,
+        "orange": $color-light-orange,
+        "yellow": $color-yellow,
+        "green": $color-green
 );
 
 // Spacing

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -16,6 +16,7 @@ $color-orange: #FF7427;
 $color-light-orange: #FFA008;
 $color-yellow: #FFC508;
 $color-green: #2FCC71;
+$color-turquoise: #24C7CC;
 
 $color-primary: $color-light-orange;
 $color-secondary: #8889A1;
@@ -33,4 +34,4 @@ $color-wip: $color-orange;
 $color-review: $color-yellow;
 $color-merge: $color-purple;
 $color-release: $color-green;
-$color-done: red; // TODO (dpordomingo): 'done' stage is defined in the API, but not in the Product designs
+$color-done: $color-turquoise;

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -8,10 +8,29 @@ $at-border-color: #E7E7EC;
  * The colors used in the charts are defined by "src/js/res/palette.js"
  */
 
+$color-blue: #147EEC;
+$color-purple: #9260E2;
+$color-pink: #FC1763;
+$color-red: #EF3837;
+$color-orange: #FF7427;
+$color-light-orange: #FFA008;
+$color-yellow: #FFC508;
+$color-green: #2FCC71;
+
+$color-primary: $color-light-orange;
+$color-secondary: #8889A1;
+$color-success: $color-green;
+$color-danger: $color-red;
+$color-warning: $color-yellow;
+$color-info: $color-blue;
+$color-light: #FAFAFB;
+$color-bright: rgba($color-secondary, .5);
+$color-dark: #121343;
+
 // The following stage colors must be in sync with the ones in "src/js/res/palette.js"
-$color-leadtime: #4DC7EE;
-$color-wip: #FF732B;
-$color-review: #FFC508;
-$color-merge: #9260E2;
-$color-release: #2FCC71;
+$color-leadtime: $color-blue;
+$color-wip: $color-orange;
+$color-review: $color-yellow;
+$color-merge: $color-purple;
+$color-release: $color-green;
 $color-done: red; // TODO (dpordomingo): 'done' stage is defined in the API, but not in the Product designs

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -66,6 +66,10 @@ html {
     font-size: 1.1rem !important;
 }
 
+.text-s {
+    font-size: 1.2rem;
+}
+
 .text-m {
     font-size: 1.3rem;
 }

--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -84,5 +84,10 @@
             border-color: $color-release;
             color: $color-release;
         }
+
+        &.badge-done {
+            border-color: $color-done;
+            color: $color-done;
+        }
     }
 }

--- a/src/sass/components/_dropdowns.scss
+++ b/src/sass/components/_dropdowns.scss
@@ -20,10 +20,11 @@
     .menuItem {
         padding-left: $menuHorizontalPadding;
         padding-right: $menuHorizontalPadding;
+        min-height: 4.3rem;
     }
 
     .invitationCreator {
-        $copyButtonWidth: 5.5rem;
+        $copyButtonWidth: 7.5rem;
 
         .desc {
             $invitationDescMargin: map-get($spacers, 3);
@@ -33,6 +34,10 @@
 
         button {
             width: $copyButtonWidth;
+
+            &:hover .text-secondary {
+                color: $white !important;
+            }
         }
     }
 }

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -11,6 +11,7 @@
     border-spacing: 0 3px !important;
     border: 0 !important;
     margin-bottom: 0 !important;
+    margin-top: 1.5rem !important;
 
     thead {
         background-color: rgba($at-border-color, 0.5) !important;
@@ -168,4 +169,23 @@
 div.dataTables_wrapper div.dataTables_length select {
     margin-left: .6rem;
     width: 5rem !important;
+}
+
+div.dataTables_wrapper div.dataTables_filter {
+    text-align: left !important;
+
+    .field-icon {
+        position: absolute;
+        opacity: 0.5;
+        left: 1.1rem;
+        top: 1rem;
+    }
+
+    .form-control {
+        width: 40rem;
+        padding-left: 3rem;
+        font-size: 1.2rem;
+        font-weight: 300;
+        margin-left: 0;
+    }
 }


### PR DESCRIPTION
This task is based on the issue [#ENG-286](https://athenianco.atlassian.net/browse/ENG-286?atlOrigin=eyJpIjoiOGVkZTk3OTVjZmVhNGNiMzhkMzUyZDJkMmM1MTMzODEiLCJwIjoiaiJ9) and related to the PR #97.

I reorganized and refactored the color variables to have only variables on `_overrides.scss` and all the color definitions on `_variables.scss`.

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>