### PR TITLE
Add Summary Metrics chart into Overview & Stages

### DIFF
--- a/docs/SummaryMetrics.md
+++ b/docs/SummaryMetrics.md
@@ -1,0 +1,69 @@
+# SummaryMetrics
+
+Design doc at https://docs.google.com/document/d/1DXLVz4L1Ag9sOUMAKdRRgVh1fk6peUrvVIp2xzeCRzQ
+
+## Common for all the stages
+
+- AVG:
+    requested separatelly
+- %:
+  ```
+  100 x Avg.stage / LeadTime
+  ```
+
+## WIP
+- Created PRs: Pull Requests Created
+  ```
+  prs.filter(from<pr.created<to).count
+  ```
+- Contributors: Number of PR creators of PRs created during the period selected
+  ```
+  prs.filter(from<pr.created<to).creators.distinct.count
+  ```
+- Repos: where commits have been pushed during the time period selected
+  ```
+  prs.filter(from<pr.created<to).repos.distinct.count
+  ```
+
+## Review
+- Reviewed PRs: Pull Requests Reviewed (PRs where a review has been submitted or a regular comment posted)
+  ```
+  prs.filter(pr.stage>=review).having(comments|reviews).count
+  ```
+- Reviewers: authors of one review or regular comment among the Reviewed PRs
+  ```
+  prs.filter(pr.stage>=review).participants.filter(p.status.oneOf(reviewer,commenter)).distinct.count
+  ```
+- Repos: where such comments have been posted
+  ```
+  prs.filter(pr.stage>=review).having(comments|reviews).repos.distinct.count
+  ```
+
+## Merge
+- Merged PRs:
+  ```
+  prs.filter(pr.merged=true).count
+  ```
+- Contributors: Number of “mergers”
+  ```
+  prs.filter(pr.merged=true).merger.distinct.count
+  ```
+- Repos: where such merges have happened
+  ```
+  prs.filter(pr.merged=true).repos.distinct.count
+  ```
+
+## Release
+- Released PRs: Pull Requests Released (PRs part of releases that happened during the time period selected)
+  ```
+  prs.filter(pr.stage=done&&pr.merged).count
+  ```
+- Releases:
+  ```
+  NOT-POSSIBLE; Should come from upcoming /releases endpoint
+  ```
+- Repos: Where a release happened
+  ```
+  prs.filter(pr.stage=done&&pr.merged).repos.distinct.count
+  ```
+

--- a/src/js/components/charts/FilledAreaChart.jsx
+++ b/src/js/components/charts/FilledAreaChart.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import {
+  FlexibleWidthXYPlot, LineMarkSeries, AreaSeries,
+  VerticalGridLines, HorizontalGridLines,
+  XAxis, YAxis,
+} from 'react-vis';
+
+import { palette } from 'js/res/palette';
+
+import { dateTime } from 'js/services/format';
+import { hexToRGBA } from 'js/services/colors';
+
+const dateFormat = dateTime.formater('%b %d')
+
+export default ({ data, average, color = palette.schemes.primary, height = 300 }) => {
+  const fillColor = hexToRGBA(color, .2);
+  return (
+    <div style={{ background: 'white' }}>
+      <FlexibleWidthXYPlot
+        height={height}
+        margin={{ left: 100 }}
+      >
+        <XAxis tickTotal={6}
+          tickFormat={dateFormat}
+        />
+        <YAxis tickTotal={3} tickFormat={dateTime.human} />
+        <HorizontalGridLines tickTotal={3} />
+        <VerticalGridLines tickTotal={6} />
+        <AreaSeries data={data} stroke="none" fill={fillColor} animation="stiff" />
+        <LineMarkSeries
+          data={data}
+          strokeWidth={2}
+          stroke={color}
+          fill="white"
+          animation="stiff"
+        />
+        <HorizontalGridLines
+          tickValues={[average]}
+          style={{ stroke: palette.schemes.trend, strokeWidth: '2px', strokeDasharray: [4, 4] }}
+          animation="stiff"
+        />
+      </FlexibleWidthXYPlot>
+    </div>
+  );
+};
+

--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -5,17 +5,33 @@ import TimeSeries from 'js/components/charts/TimeSeries';
 import Badge from 'js/components/ui/Badge';
 import { BigNumber } from 'js/components/ui/Typography';
 import Info from 'js/components/ui/Info'
+import { SmallTitle } from 'js/components/ui/Typography';
 
-import { number } from 'js/services/format';
+import { dateTime, number } from 'js/services/format';
 
-export default ({ title, metrics }) => {
+import { palette } from 'js/res/palette';
+
+import FilledAreaChart from 'js/components/charts/FilledAreaChart';
+
+export default ({ conf, metrics, children }) => {
   return (
     <div>
-      <div className="row">
-        <div className="col-12">
-          <p className="text-centerleft font-weight-bold text-lg">{title}</p>
-        </div>
-      </div>
+      <SummaryMetric
+        chart={conf && conf.data && <FilledAreaChart
+          data={conf.data}
+          height={280}
+          color={palette.stages[conf.stageName]}
+          average={conf.avg}
+        />}
+        data={{
+          metric: conf.stageName,
+          title: conf.title,
+          average: conf.avg,
+          variation: conf.variation,
+        }}
+      >
+        {children}
+      </SummaryMetric>
       {
         metrics.map((chart, i) => {
           return <Metric key={i}
@@ -31,6 +47,45 @@ export default ({ title, metrics }) => {
     </div>
   );
 }
+
+const SummaryMetric = ({ data, chart, children }) => {
+  return (
+    <div className={classnames('summary-metric card mb-4 px-2', data.metric)}>
+      <div className="card-body">
+        <div className="row">
+          <div className="col-4">
+            <header className="font-weight-bold text-lg mt-2">{data.title}</header>
+            <div className="pl-2">
+              <div className="font-weight-bold mt-4 mb-3 pb-2 border-bottom">
+                <BigNumber content={dateTime.human(data.average)} isXL />
+                <Badge value={number.round(data.variation)} className="ml-2" trend />
+              </div>
+              <div>
+                {children}
+              </div>
+            </div>
+          </div>
+          <div className="col-8 align-self-center">
+            {chart}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const StageSummaryKPI = ({ data }) => {
+  return (
+    <div className="row">
+      {data.map((kpi, key) =>
+        <div className="col-md-6 mb-3" key={key}>
+          <div className="mb-2"><SmallTitle content={kpi[0]} /></div>
+          <div><BigNumber content={kpi[1]} /></div>
+        </div>
+      )}
+    </div>
+  );
+};
 
 const Metric = ({ insights, title, chart }) => (
   <div className="card mb-4">

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -16,7 +16,7 @@ export default ({ prs, stages, activeCard }) => {
             {
                 stages.map(
                     (card, i) => (
-                        <div className={classnames('col-md-3 pipeline-stage', card.stageName, activeCard === i && 'active')} key={i}>
+                        <div className={classnames('col-md-3 pipeline-stage', card.stageName, activeCard === card.slug && 'active')} key={i}>
                             <span data-toggle="tooltip" data-placement="bottom" title={card.event.before} className="event-before" />
                             <Link to={'/stage/' + card.slug}>
                                 <Stage
@@ -26,7 +26,7 @@ export default ({ prs, stages, activeCard }) => {
                                     variation={card.variation}
                                     color={card.color}
                                     data={card.data}
-                                    active={activeCard === i}
+                                    active={activeCard === card.slug}
                                     badge={prs.filter(pr => pr.stage === card.stageName).length}
                                 >
                                 </Stage>
@@ -58,7 +58,7 @@ const Stage = ({ title, text, hint, badge, variation, color, data, active, onCli
                         {text ? <Badge trend value={number.round(variation)} /> : ''}
                     </div>
                     <div className="col-7 pl-2" style={{ height: 55 }}>
-                        <PipelineCardMiniChart data={data} color={color} active={active} />
+                        {data && <PipelineCardMiniChart data={data} color={color} active={active} />}
                     </div>
                 </div>
             </div>

--- a/src/js/context/Pipeline.jsx
+++ b/src/js/context/Pipeline.jsx
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+
+const PipelineContext = React.createContext({ leadtime: {}, stages: [] });
+
+/**
+ * Returns the leadtime and stages metrics within the active filters.
+ * @return {leadtime <{metric}>, stages <Array<{metric}>>} leadtime and stages metrics.
+ */
+export const usePipelineContext = () => useContext(PipelineContext);
+
+export default ({ metrics, children }) => {
+    return (
+        <PipelineContext.Provider value={metrics}>
+            {children}
+        </PipelineContext.Provider >
+    );
+};

--- a/src/js/pages/Pipeline.jsx
+++ b/src/js/pages/Pipeline.jsx
@@ -5,15 +5,18 @@ import Page from 'js/pages/templates/Page';
 import Body from 'js/pages/pipeline/Body';
 import Filters from 'js/pages/pipeline/Filters';
 import PullRequests from 'js/pages/pipeline/PullRequests';
+import Pipeline from 'js/pages/pipeline/Pipeline';
 
 export default ({ children }) => {
     return (
         <Page>
             <Filters>
                 <PullRequests>
-                    <Body>
-                        {children}
-                    </Body>
+                    <Pipeline>
+                        <Body>
+                            {children}
+                        </Body>
+                    </Pipeline>
                 </PullRequests>
             </Filters>
         </Page>

--- a/src/js/pages/pipeline/Pipeline.jsx
+++ b/src/js/pages/pipeline/Pipeline.jsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from 'react';
+
+import PipelineContext from 'js/context/Pipeline';
+import { useAuth0 } from 'js/context/Auth0';
+import { useUserContext } from 'js/context/User';
+import { useFiltersContext } from 'js/context/Filters';
+
+import { getMetrics, fetchApi } from 'js/services/api';
+import { number } from 'js/services/format';
+
+import { palette } from 'js/res/palette';
+
+export const pipelineStagesConf = [
+    {
+        title: 'Lead Time',
+        slug: 'overview',
+        metric: 'lead-time',
+        stageName: 'leadtime',
+        color: palette.stages.leadtime,
+        hint: 'Trom the 1st commit of the Pull Requests until the code is being used in production',
+        event: {
+            before: 'First Commit',
+            after: 'Release',
+        },
+    }, {
+        title: 'Work in progress',
+        slug: 'work-in-progress',
+        metric: 'wip-time',
+        stageName: 'wip',
+        color: palette.stages.wip,
+        hint: 'From the 1st commit of the Pull Request until the review is requested',
+        event: {
+            before: 'First Commit',
+            after: 'Review Requested',
+        },
+        summary: () => {
+            return [
+                ['proportion of the lead time', number.percentage(30)],
+                ['pull requests created', 10],
+                ['contributors', 5],
+                ['repositories', 2],
+            ];
+        },
+    }, {
+        title: 'Review',
+        slug: 'review',
+        metric: 'review-time',
+        stageName: 'review',
+        color: palette.stages.review,
+        hint: 'From the moment the review is requested until the Pull Request is approved',
+        event: {
+            before: 'Review Requested',
+            after: 'Approved',
+        },
+        summary: () => {
+            return [
+                ['proportion of the lead time', number.percentage(20)],
+                ['pull requests reviewed', 54],
+                ['reviewers', 12],
+                ['repositories', 4],
+            ];
+        },
+    }, {
+        title: 'Merge',
+        slug: 'merge',
+        metric: 'merging-time',
+        stageName: 'merge',
+        color: palette.stages.merge,
+        hint: 'From the moment the Pull Request is approved until it gets merged',
+        event: {
+            before: 'Approved',
+            after: 'Merged',
+        },
+        summary: () => {
+            return [
+                ['proportion of the lead time', number.percentage(45)],
+                ['pull requests merged', 2],
+                ['contributors', 12],
+                ['repositories', 8],
+            ];
+        },
+    }, {
+        title: 'Release',
+        slug: 'release',
+        metric: 'release-time',
+        stageName: 'release',
+        color: palette.stages.release,
+        hint: 'From the moment the Pull Request gets merged until it is shipped into production',
+        event: {
+            before: 'Merged',
+            after: 'Released',
+        },
+        summary: () => {
+            return [
+                ['proportion of the lead time', number.percentage(5)],
+                ['pull requests released', 1],
+                ['releases', 2],
+                ['repositories', 1],
+            ];
+        },
+    },
+];
+
+const mainStagesNames = ['wip', 'review', 'merge', 'release'];
+
+export const getStage = (stages, slug) => stages.find(conf => conf.slug === slug);
+
+export default ({ children }) => {
+    const { getTokenSilently } = useAuth0();
+    const userContext = useUserContext();
+
+    const [pipelineState, setPipelineState] = useState({ leadtime: {}, stages: [] });
+    const { dateInterval, repositories, contributors } = useFiltersContext();
+
+    useEffect(() => {
+        if (!userContext || !repositories.length) {
+            return;
+        };
+
+        getTokenSilently()
+            .then(token => fetchApi(token, getMetrics, userContext.defaultAccount.id, dateInterval, repositories, contributors))
+            .then(data => {
+                let leadtime = {};
+                const stages = [];
+                pipelineStagesConf.forEach(metricConf => {
+                    const metric = { ...metricConf, ...data[metricConf.metric] };
+                    if (mainStagesNames.indexOf(metricConf.stageName) >= 0) {
+                        stages.push(metric);
+                    } else if (metricConf.stageName === 'leadtime') {
+                        leadtime = metric;
+                    }
+                });
+
+                if (leadtime.avg) {
+                    stages.forEach(stage => stage.leadTimePercentage = 100 * stage.avg / leadtime.avg);
+                }
+
+                setPipelineState({ leadtime, stages });
+            })
+            .catch(err => console.error('Could not get pipeline metrics', err));
+    }, [userContext, dateInterval, repositories, contributors]);
+
+    return (
+        <PipelineContext metrics={pipelineState}>
+            {children}
+        </PipelineContext>
+    )
+};

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -13,7 +13,7 @@ export const getPRs = async (token, accountId, dateInterval, repos, contributors
   const api = buildApi(token);
   const filter = new FilterPullRequestsRequest(accountId, dateTime.ymd(dateInterval.from), dateTime.ymd(dateInterval.to));
   filter.in = repos;
-  filter.stages = ['wip', 'review', 'merge', 'release'];
+  filter.stages = ['wip', 'review', 'merge', 'release', 'done'];
   if (contributors.length) {
     filter.with = {
       author: contributors,

--- a/src/js/services/format.js
+++ b/src/js/services/format.js
@@ -44,7 +44,9 @@ const human = seconds => {
 };
 
 export const dateTime = {
+    formater: timeFormat,
     ymd: ymdFormat,
+
     milliseconds: secondsString => {
         if (!secondsString) {
             return 0;

--- a/src/sass/components/_pipeline.scss
+++ b/src/sass/components/_pipeline.scss
@@ -120,3 +120,50 @@
         }
     }
 }
+
+.summary-metric {
+    &.wip {
+        border-color: $color-wip;
+
+        header {
+            color: $color-wip;
+        }
+    }
+    &.review {
+        border-color: $color-review;
+
+        header {
+            color: $color-review;
+        }
+    }
+    &.merge {
+        border-color: $color-merge;
+
+        header {
+            color: $color-merge;
+        }
+    }
+    &.release {
+        border-color: $color-release;
+
+        header {
+            color: $color-release;
+        }
+    }
+}
+
+.leadtime-proportion {
+    height: 5px;
+    &.wip {
+        background: $color-wip;
+    }
+    &.review {
+        background: $color-review;
+    }
+    &.merge {
+        background: $color-merge;
+    }
+    &.release {
+        background: $color-release;
+    }
+}


### PR DESCRIPTION
This PR adds the Summary Charts into Overview and to all the pipeline stages.

- fef6c1a It is added a new chart: `FilledAreaChart`
- d8d6436 Add SummaryMetric component into Overview and each Stage; It's using already retrieved `prs`, `leadtime` and `stages` which are stored in `PRsContext` and `PipelineContext`. There is no data calculation in this commit, so it's used mocked data instead.
- ed5c3e5 Calculates the aggregations needed for the Summary Metrics following ￼[DesignDoc](https://docs.google.com/document/d/1DXLVz4L1Ag9sOUMAKdRRgVh1fk6peUrvVIp2xzeCRzQ)

![image](https://user-images.githubusercontent.com/2437584/76284847-9f963e80-629e-11ea-840a-fcc9dc44fe4e.png)
![image](https://user-images.githubusercontent.com/2437584/76284932-d3716400-629e-11ea-81ad-1698e1bfdf2b.png)
![image](https://user-images.githubusercontent.com/2437584/76284873-b3da3b80-629e-11ea-8278-6aa8eaec898e.png)
![image](https://user-images.githubusercontent.com/2437584/76284889-bb99e000-629e-11ea-953b-03fb8730be62.png)
![image](https://user-images.githubusercontent.com/2437584/76284909-c6ed0b80-629e-11ea-8ee9-4b642d9b738d.png)
