### PR TITLE
Adding tooltips style guide for the charts

### DIFF
--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -26,6 +26,7 @@ import NotFound404 from 'js/pages/NotFound404';
 import Prototypes from 'js/pages/prototypes';
 import Charts from 'js/pages/prototypes/Charts';
 import MetricGroups from 'js/pages/prototypes/MetricGroups';
+import Tooltips from 'js/pages/prototypes/Tooltips';
 
 export default () => {
 
@@ -80,6 +81,7 @@ export default () => {
               <Prototypes prototypes={{
                 'charts': <Charts />,
                 'metrics-groups': <MetricGroups />,
+                'tooltips': <Tooltips />,
               }} />
             </Route>
             <Route path='*'>

--- a/src/js/pages/prototypes/Tooltips.jsx
+++ b/src/js/pages/prototypes/Tooltips.jsx
@@ -1,0 +1,237 @@
+import React, { useEffect } from 'react';
+import $ from 'jquery';
+
+import TooltipInfo from 'js/pages/prototypes/tooltip-info/TooltipInfo';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+export default ({ content }) => {
+    useEffect(() => {
+        $('[data-toggle="tooltip"]').tooltip && $('[data-toggle="tooltip"]').tooltip();
+    }, [])
+
+    return (
+        <div>
+            <div className="row">
+                <div className="col-12 mb-3">
+                    <p className="text-centerleft font-weight-light text-dark text-lg">Tooltips</p>
+                </div>
+            </div>
+            <div className="row mb-5">
+                <div className="col-12">
+                    <h4 className="text-centerleft text-dark font-weight-light mr-2">User tooltips</h4>
+                    <MainTooltip title="User with PRs and comments"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-center p-1'>
+                                                <div class='w-100 mb-2'>
+                                                    <img src='https://randomuser.me/api/portraits/women/44.jpg'
+                                                         class='user-avatar inline-block' height='30' width='30'/>
+                                                    <span class='ml-2 inline-block text-dark text-m align-middle'>jennifer_38</span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='user-info text-secondary font-weight-light m-0'>
+                                                        <i class='fas fa-code-branch mr-1'></i>
+                                                        <span class='mr-3'>10</span>
+                                                        <i class='far fa-comment-alt mr-1'></i>
+                                                        <span>8</span></p>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                </div>
+            </div>
+
+            <div className="row mb-5">
+                <div className="col-12">
+                    <h4 className="text-centerleft text-dark font-weight-light mr-2">Text and numbers</h4>
+                    <MainTooltip title="One title and one number"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-center p-1'>
+                                                <div class='w-100'>
+                                                    <p class='text-uppercase text-secondary text-xs mb-1'>PRs Created</p>
+                                                    <span class='big-number font-weight-bold d-inline-block align-middle text-dark text-lg'>49</span>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                    <MainTooltip title="Two titles and two numbers"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-left p-1'>
+                                                <div class='w-100'>
+                                                    <p class='text-uppercase text-secondary text-xs mb-1'>Average time to merge</p>
+                                                    <span class='font-weight-bold d-inline-block align-middle text-dark text-m mb-2'>18 hours</span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='text-uppercase text-secondary text-xs mb-1'>Developers with merge privileges</p>
+                                                    <span class='font-weight-bold d-inline-block align-middle text-dark text-m'>6</span>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                </div>
+            </div>
+            <div className="row mb-5">
+                <div className="col-12">
+                    <h4 className="text-centerleft text-dark font-weight-light mr-2">Pull requests</h4>
+
+                    <MainTooltip title="Regular Pull Request"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-left p-1'>
+                                                <div class='w-100'>
+                                                    <p class='text-uppercase text-secondary text-xs mb-1'>#458</p>
+                                                    <span class='text-s'><span class='text-secondary'>src-d/go-git:</span> <span className=' text-dark font-weight-bold'>git: remove potentially duplicate check for unstaged files</span></span>
+                                                </div>
+                                                <div class='w-100 mt-2'>
+                                                    <img src='https://randomuser.me/api/portraits/women/44.jpg' class='user-avatar inline-block'
+                                                         height='18' width='18'/>
+                                                    <span class='ml-2 inline-block text-secondary font-weight-light align-middle'>6 hours ago by <span
+                                                        class='text-dark'>jennifer_38</span></span>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+
+                    <MainTooltip title="Pull Request waiting for Review"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-left p-1'>
+                                                <div class='w-100'>
+                                                    <p class='text-uppercase text-secondary text-xs mb-1'>#458</p>
+                                                    <span class='text-s'><span class='text-secondary'>src-d/go-git:</span> <span className=' text-dark font-weight-bold'>git: remove potentially duplicate check for unstaged files</span></span>
+                                                </div>
+                                                <div class='w-100 my-2 text-orange'>
+                                                    <i class='far fa-clock mr-1'></i>
+                                                    <span>Waiting review for 16 hours</span>
+                                                </div>
+                                                <div class='w-100 mt-2'>
+                                                    <img src='https://randomuser.me/api/portraits/women/44.jpg'
+                                                         class='user-avatar inline-block'
+                                                         height='18' width='18'/>
+                                                    <span class='ml-2 inline-block text-secondary font-weight-light align-middle'>Created by <span
+                                                        class='text-dark'>jennifer_38</span></span>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+
+                    <MainTooltip title="Pull Request Reviewed"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-left p-1'>
+                                                <div class='w-100'>
+                                                    <p class='text-uppercase text-secondary text-xs mb-1'>#458</p>
+                                                    <span class='text-s'><span class='text-secondary'>src-d/go-git:</span> <span className=' text-dark font-weight-bold'>git: remove potentially duplicate check for unstaged files</span></span>
+                                                </div>
+                                                <div class='w-100 my-2 text-turquoise'>
+                                                    <i class='far fa-clock mr-1'></i>
+                                                    <span>Waited review for 7 hours</span>
+                                                </div>
+                                                <div class='w-100 mt-2'>
+                                                    <img src='https://randomuser.me/api/portraits/women/44.jpg'
+                                                         class='user-avatar inline-block'
+                                                         height='18' width='18'/>
+                                                    <span class='ml-2 inline-block text-secondary font-weight-light align-middle'>Created by <span
+                                                        class='text-dark'>jennifer_38</span></span>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+
+
+                </div>
+            </div>
+            <div className="row mb-5">
+                <div className="col-12">
+                    <h4 className="text-centerleft text-dark font-weight-light mr-2">Repositories</h4>
+
+                    <MainTooltip title="Single repository"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-center p-1'>
+                                                <div class='w-100 mb-2'>
+                                                    <span class='text-secondary text-m align-middle'>athenian/api</span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='text-m text-dark m-0'>
+                                                        <i class='far fa-clock text-blue mr-1'></i>
+                                                        <span class='mr-3'>38 min</span>
+                                                        <i class='far fa-user text-secondary mr-1'></i>
+                                                        <span>5</span></p>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                    <MainTooltip title="Multiple repositories"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-center p-1'>
+                                                <div class='w-100 mb-2'>
+                                                    <span class='text-secondary text-m align-middle'>5 repositories</span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='text-m text-dark m-0'>
+                                                        <i class='far fa-clock text-orange mr-1'></i>
+                                                        <span class='mr-3'>38 min</span>
+                                                        <i class='far fa-user text-secondary mr-1'></i>
+                                                        <span>5</span></p>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                </div>
+            </div>
+            <div className="row mb-5">
+                <div className="col-12">
+                    <h4 className="text-centerleft text-dark font-weight-light mr-2">Releases</h4>
+
+                    <MainTooltip title="Single release"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-center p-1'>
+                                                <div class='w-100 mb-2'>
+                                                    <span class='text-dark text-m align-middle'>webapp <span class='text-secondary'>v1.3.2</span></span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='text-s m-0'>
+                                                        <i class='fas fa-code-branch text-green mr-1'></i>
+                                                        <span class='text-secondary mr-2'>9</span>
+                                                        <span class='mr-1 text-green'>+1,543</span>
+                                                        <span class='text-danger'>-504</span>
+                                                        </p>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                    <MainTooltip title="Multiple releases"
+                                 hint="<div class='card'>
+                                            <div class='card-body text-center p-1'>
+                                                <div class='w-100 mb-2'>
+                                                    <span class='text-dark text-m align-middle'>webapp <span class='text-secondary'>v1.3.2</span></span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='text-s m-0'>
+                                                        <i class='fas fa-code-branch text-green mr-1'></i>
+                                                        <span class='text-secondary mr-2'>9</span>
+                                                        <span class='mr-1 text-green'>+1,543</span>
+                                                        <span class='text-danger'>-504</span>
+                                                    </p>
+                                                </div>
+                                                <div class='w-100 mt-3 mb-2'>
+                                                    <span class='text-dark text-m align-middle'>api <span class='text-secondary'>v1.4.0</span></span>
+                                                </div>
+                                                <div class='w-100'>
+                                                    <p class='text-s m-0'>
+                                                        <i class='fas fa-code-branch text-green mr-1'></i>
+                                                        <span class='text-secondary mr-2'>5</span>
+                                                        <span class='mr-1 text-green'>+328</span>
+                                                        <span class='text-danger'>-139</span>
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+const MainTooltip = ({ title, hint }) => (
+    <div>
+        {title && <TooltipInfo title={title} content={hint} />}
+    </div>
+);

--- a/src/js/pages/prototypes/tooltip-info/TooltipInfo.jsx
+++ b/src/js/pages/prototypes/tooltip-info/TooltipInfo.jsx
@@ -1,0 +1,16 @@
+import React, { useEffect } from 'react';
+import $ from 'jquery';
+
+export default ({ title, content}) => {
+    useEffect(() => {
+        $('[data-toggle="tooltip"]').tooltip && $('[data-toggle="tooltip"]').tooltip({
+            template: '<div class="tooltip tooltip-light" role="tooltip"><div class="arrow"></div><div class="tooltip-inner"></div></div>'
+        });
+    }, [])
+
+    return (
+        <span data-toggle="tooltip" data-html="true" data-placement="bottom" title={content} className="tooltip-demo text-centerleft font-weight-light text-m mt-2 mb-3">
+            <span>{title}</span>
+        </span>
+    );
+};

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -77,3 +77,19 @@ html {
 .text-lg {
     font-size: 2.1rem !important;
 }
+
+.text-orange {
+    color: $color-light-orange;
+}
+
+.text-green {
+    color: $color-green;
+}
+
+.text-turquoise {
+    color: $color-turquoise;
+}
+
+.text-blue {
+    color: $color-blue;
+}

--- a/src/sass/components/_tooltips.scss
+++ b/src/sass/components/_tooltips.scss
@@ -15,3 +15,48 @@
         text-align: left;
     }
 }
+
+.tooltip-light {
+
+    .tooltip-inner {
+        background: $white;
+        box-shadow: 0 0 2px rgba(0,0,0,0.02);
+        color: $dark;
+        font-weight: 500;
+    }
+
+    &.tooltip.bs-tooltip-right .arrow:before {
+        border-right-color: $white !important;
+    }
+    &.tooltip.bs-tooltip-left .arrow:before {
+        border-left-color: $white !important;
+    }
+    &.tooltip.bs-tooltip-bottom .arrow:before {
+        border-bottom-color: $white !important;
+    }
+    &.tooltip.bs-tooltip-top .arrow:before {
+        border-top-color: $white !important;
+    }
+
+    .card {
+        border: none;
+    }
+}
+
+// User tooltip
+
+.user-avatar {
+    box-shadow: 0 0 4px rgba(0,0,0,0.1);
+    border-radius: 2rem;
+    border: 2px solid white;
+    vertical-align: middle;
+    cursor: default;
+}
+
+.user-info {
+    font-size: 1.5rem;
+}
+
+.tooltip-demo {
+    display: inline-block;
+}


### PR DESCRIPTION
This PR is related to the issue [#ENG-306](https://athenianco.atlassian.net/browse/ENG-306). It adds a static page with all the layouts and examples of the chart tooltips, adding the necessary styles. It can be reviewed here: http://localhost:3000/tooltips

- Main page:

![image](https://user-images.githubusercontent.com/14981468/76344072-3dbaf080-6301-11ea-862c-ad46166e314e.png)


- User tooltip:

![image](https://user-images.githubusercontent.com/14981468/76344104-4ca1a300-6301-11ea-96cf-06bfe469e88d.png)


- Text and numbers:

![image](https://user-images.githubusercontent.com/14981468/76344118-55927480-6301-11ea-8b09-81fe9efa934e.png)

![image](https://user-images.githubusercontent.com/14981468/76344141-5d521900-6301-11ea-8155-36c5a068e06e.png)


- Pull requests:

![image](https://user-images.githubusercontent.com/14981468/76344216-84a8e600-6301-11ea-8e85-246b044c1811.png)

![image](https://user-images.githubusercontent.com/14981468/76344241-8c688a80-6301-11ea-8437-d2bd96a8f065.png)

![image](https://user-images.githubusercontent.com/14981468/76344258-94282f00-6301-11ea-9fe7-6b389fe9a0c5.png)


- Repositories:

![image](https://user-images.githubusercontent.com/14981468/76344310-a4d8a500-6301-11ea-97de-4773731bf883.png)

![image](https://user-images.githubusercontent.com/14981468/76344326-ab671c80-6301-11ea-8f8a-229ebdfd026a.png)


- Releases:

![image](https://user-images.githubusercontent.com/14981468/76344362-bae66580-6301-11ea-94bc-d7f0ca0cab15.png)

![image](https://user-images.githubusercontent.com/14981468/76344382-c5a0fa80-6301-11ea-8026-92af2e260545.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>