### PR TITLE
Use imported bootstrap-daterangepicker styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.12.0",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/react-fontawesome": "^0.1.8",
+    "bootstrap-daterangepicker": "^3.0.5",
     "classnames": "^2.2.6",
     "datatables.net": "^1.10.20",
     "datatables.net-dt": "^1.10.20",

--- a/src/sass/components/_datepicker.scss
+++ b/src/sass/components/_datepicker.scss
@@ -1,119 +1,27 @@
-// Based on https://github.com/dangrossman/daterangepicker
-
 .daterangepicker {
-    position: absolute;
-    color: inherit;
     background-color: $color-light;
     border-radius: 0;
     border: 1px solid $at-border-color;
     box-shadow: 2px 2px 2px rgba(0,0,0,0.05);
-    width: 278px;
-    max-width: none;
-    padding: 0;
-    margin-top: 7px;
-    top: 100px;
-    left: 20px;
-    z-index: 3001;
-    display: none;
+    font-family: $font-family-sans-serif;
     font-size: 1rem;
     font-weight: 300;
-    line-height: 1em;
-}
-
-.daterangepicker:before, .daterangepicker:after {
-    position: absolute;
-    display: inline-block;
-    border-bottom-color: rgba(0, 0, 0, 0.2);
-    content: '';
 }
 
 .daterangepicker:before {
-    top: -7px;
-    border-right: 7px solid transparent;
-    border-left: 7px solid transparent;
     border-bottom: 7px solid $at-border-color;
 }
 
 .daterangepicker:after {
-    top: -6px;
-    border-right: 6px solid transparent;
     border-bottom: 6px solid $at-main-bg;
-    border-left: 6px solid transparent;
-}
-
-.daterangepicker.opensleft:before {
-    right: 9px;
-}
-
-.daterangepicker.opensleft:after {
-    right: 10px;
-}
-
-.daterangepicker.openscenter:before {
-    left: 0;
-    right: 0;
-    width: 0;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.daterangepicker.openscenter:after {
-    left: 0;
-    right: 0;
-    width: 0;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-.daterangepicker.opensright:before {
-    left: 9px;
-}
-
-.daterangepicker.opensright:after {
-    left: 10px;
-}
-
-.daterangepicker.drop-up {
-    margin-top: -7px;
-}
-
-.daterangepicker.drop-up:before {
-    top: initial;
-    bottom: -7px;
-    border-bottom: initial;
-    border-top: 7px solid #ccc;
-}
-
-.daterangepicker.drop-up:after {
-    top: initial;
-    bottom: -6px;
-    border-bottom: initial;
-    border-top: 6px solid #fff;
-}
-
-.daterangepicker.single .daterangepicker .ranges, .daterangepicker.single .drp-calendar {
-    float: none;
-}
-
-.daterangepicker.single .drp-selected {
-    display: none;
-}
-
-.daterangepicker.show-calendar .drp-calendar {
-    display: block;
-}
-
-.daterangepicker.show-calendar .drp-buttons {
-    display: block;
-}
-
-.daterangepicker.auto-apply .drp-buttons {
-    display: none;
 }
 
 .daterangepicker .drp-calendar {
-    display: none;
     max-width: 210px;
+}
+
+.daterangepicker .drp-calendar.left {
+    padding: 10px 15px 10px 10px;
 }
 
 .daterangepicker .drp-calendar:first-child {
@@ -124,45 +32,13 @@
     padding-right: 50px !important;
 }
 
-.daterangepicker .drp-calendar.left {
-    padding: 10px 15px 10px 10px;
-}
-
-.daterangepicker .drp-calendar.single .calendar-table {
-    border: none;
-}
-
-.daterangepicker .calendar-table .next span, .daterangepicker .calendar-table .prev span {
-    color: #fff;
-    border: solid black;
-    border-width: 0 2px 2px 0;
-    border-radius: 0;
-    display: inline-block;
-    padding: 3px;
-}
-
-.daterangepicker .calendar-table .next span {
-    transform: rotate(-45deg);
-    -webkit-transform: rotate(-45deg);
-}
-
-.daterangepicker .calendar-table .prev span {
-    transform: rotate(135deg);
-    -webkit-transform: rotate(135deg);
-}
-
-.daterangepicker .calendar-table th, .daterangepicker .calendar-table td {
-    white-space: nowrap;
-    text-align: center;
-    vertical-align: middle;
+.daterangepicker .calendar-table th,
+.daterangepicker .calendar-table td {
     min-width: 22px;
     width: 22px;
     height: 18px;
     line-height: 1.8rem;
-    border-radius: 4px;
-    border: 1px solid transparent;
-    white-space: nowrap;
-    cursor: pointer;
+    font-size: unset;
     font-weight: 300;
 }
 
@@ -202,53 +78,38 @@
 }
 
 .daterangepicker .calendar-table {
-    border-radius: 4px;
+    border: unset;
+    background-color: unset;
 }
 
-.daterangepicker .calendar-table table {
-    width: 100%;
-    margin: 0;
-    border-spacing: 0;
-    border-collapse: collapse;
-}
-
-.daterangepicker td.available:hover, .daterangepicker th.available:hover {
+.daterangepicker td.available:hover,
+.daterangepicker th.available:hover {
     background-color: rgba($secondary,0.2);
-    border-color: transparent;
-    color: inherit;
 }
 
-.daterangepicker td.week, .daterangepicker th.week {
+.daterangepicker td.week,
+.daterangepicker th.week {
     display: none;
 }
 
-.daterangepicker td.off, .daterangepicker td.off.available, .daterangepicker td.off.in-range, .daterangepicker td.off.start-date, .daterangepicker td.off.end-date {
-    border-color: transparent;
+.daterangepicker td.off,
+.daterangepicker td.off.available,
+.daterangepicker td.off.in-range,
+.daterangepicker td.off.start-date,
+.daterangepicker td.off.end-date {
+    background-color: unset;
     color: rgba($color-dark,0.2);
 }
 
 .daterangepicker td.in-range {
-    background-color: rgba($color-light-orange, 0.1);
-    border-color: transparent;
+    background-color: rgba($color-light-orange, 0.1) !important;
     color: $color-dark;
-    border-radius: 0;
 }
 
-.daterangepicker td.start-date {
-    border-radius: 4px 0 0 4px;
-}
-
-.daterangepicker td.end-date {
-    border-radius: 0 4px 4px 0;
-}
-
-.daterangepicker td.start-date.end-date {
-    border-radius: 4px;
-}
-
-.daterangepicker td.active, .daterangepicker td.active:hover {
-    background-color: $color-orange;
-    border-color: 1px solid $white;
+.daterangepicker td.active,
+.daterangepicker td.active:hover {
+    background-color: $color-orange !important;
+    border-color: $white;
     color: $white;
 }
 
@@ -256,196 +117,19 @@
     color: $color-dark;
     font-size: 1.2rem;
     font-weight: 500;
-    width: auto;
-}
-
-.daterangepicker td.disabled, .daterangepicker option.disabled {
-    color: #999;
-    cursor: not-allowed;
-    text-decoration: line-through;
-}
-
-.daterangepicker select.monthselect, .daterangepicker select.yearselect {
-    font-size: 12px;
-    padding: 1px;
-    height: auto;
-    margin: 0;
-    cursor: default;
-}
-
-.daterangepicker select.monthselect {
-    margin-right: 2%;
-    width: 56%;
-}
-
-.daterangepicker select.yearselect {
-    width: 40%;
-}
-
-.daterangepicker select.hourselect, .daterangepicker select.minuteselect, .daterangepicker select.secondselect, .daterangepicker select.ampmselect {
-    width: 50px;
-    margin: 0 auto;
-    background: #eee;
-    border: 1px solid #eee;
-    padding: 2px;
-    outline: 0;
-    font-size: 12px;
-}
-
-.daterangepicker .calendar-time {
-    text-align: center;
-    margin: 4px auto 0 auto;
-    line-height: 30px;
-    position: relative;
-}
-
-.daterangepicker .calendar-time select.disabled {
-    color: #ccc;
-    cursor: not-allowed;
 }
 
 .daterangepicker .drp-buttons {
     background: $white;
-    clear: both;
-    text-align: right;
-    padding: 8px;
-    border-top: 1px solid #ddd;
-    display: none;
-    line-height: 12px;
-    vertical-align: middle;
 }
 
 .daterangepicker .drp-selected {
     display: none;
-    font-size: 12px;
-    padding-right: 8px;
-}
-
-.daterangepicker .drp-buttons .btn {
-    margin-left: 8px;
-    font-size: 12px;
-    padding: 4px 8px;
-}
-
-.daterangepicker.show-ranges.single.rtl .drp-calendar.left {
-    border-right: 1px solid #ddd;
-}
-
-.daterangepicker.show-ranges.single.ltr .drp-calendar.left {
-    border-left: 1px solid #ddd;
-}
-
-.daterangepicker.show-ranges.rtl .drp-calendar.right {
-    border-right: 1px solid #ddd;
-}
-
-.daterangepicker.show-ranges.ltr .drp-calendar.left {
-    border-left: 1px solid #ddd;
-}
-
-.daterangepicker .ranges {
-    float: none;
-    text-align: left;
-    margin: 0;
-}
-
-.daterangepicker.show-calendar .ranges {
-    margin-top: 8px;
-}
-
-.daterangepicker .ranges ul {
-    list-style: none;
-    margin: 0 auto;
-    padding: 0;
-    width: 100%;
-}
-
-.daterangepicker .ranges li {
-    font-size: 12px;
-    padding: 8px 12px;
-    cursor: pointer;
-}
-
-.daterangepicker .ranges li:hover {
-    background-color: #eee;
-}
-
-.daterangepicker .ranges li.active {
-    background-color: #08c;
-    color: #fff;
 }
 
 // Large screens
 @media (min-width: 564px) {
     .daterangepicker {
         width: 430px;
-    }
-
-    .daterangepicker .ranges ul {
-        width: 140px;
-    }
-
-    .daterangepicker.single .ranges ul {
-        width: 100%;
-    }
-
-    .daterangepicker.single .drp-calendar.left {
-        clear: none;
-    }
-
-    .daterangepicker.single .ranges, .daterangepicker.single .drp-calendar {
-        float: left;
-    }
-
-    .daterangepicker {
-        direction: ltr;
-        text-align: left;
-    }
-
-    .daterangepicker .drp-calendar.left {
-        clear: left;
-        margin-right: 0;
-    }
-
-    .daterangepicker .drp-calendar.left .calendar-table {
-        border-right: none;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-    }
-
-    .daterangepicker .drp-calendar.right {
-        margin-left: 0;
-    }
-
-    .daterangepicker .drp-calendar.right .calendar-table {
-        border-left: none;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-    }
-
-    .daterangepicker .drp-calendar.left .calendar-table {
-        padding-right: 8px;
-    }
-
-    .daterangepicker .ranges, .daterangepicker .drp-calendar {
-        float: left;
-    }
-}
-
-@media (min-width: 730px) {
-    .daterangepicker .ranges {
-        width: auto;
-    }
-
-    .daterangepicker .ranges {
-        float: left;
-    }
-
-    .daterangepicker.rtl .ranges {
-        float: right;
-    }
-
-    .daterangepicker .drp-calendar.left {
-        clear: none !important;
     }
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -3,6 +3,7 @@
 
 @import '~react-vis/dist/style.css';
 @import '~@dpordomingo/startbootstrap-sb-admin-2/scss/sb-admin-2.scss';
+@import '~bootstrap-daterangepicker/daterangepicker.css';
 
 @import 'base/typography';
 @import 'base/utilities';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,6 +2431,14 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap-daterangepicker@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/bootstrap-daterangepicker/-/bootstrap-daterangepicker-3.0.5.tgz#dc10db6b4854cc63ebb5b17dac55edd7318dcbad"
+  integrity sha512-WdTNB5ZKCpqZltcRkzeE6Xmwp/b8yPnuwsHfqP5mGP2VIV/kzd/6VuTIKEjuskDcsLAYW38LXGjcSm2TBNRdTw==
+  dependencies:
+    jquery ">=1.10"
+    moment "^2.9.0"
+
 bootstrap@4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.3.1.tgz#280ca8f610504d99d7b6b4bfc4b68cec601704ac"
@@ -4077,9 +4085,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.341, electron-to-chromium@^1.3.363:
-  version "1.3.374"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.374.tgz#eb539bfcac8ec51de417038548c3bc93745134bb"
-  integrity sha512-M4Y9onOJ4viRk3A4M/LH+r9+1zQioRZJvGJn/S/o7KaBJQLgFiaHMUlDwM0QMJd5ki6hFxKiWdC6jp5Ub0zMmw==
+  version "1.3.375"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.375.tgz#e290d59d316024e5499057944c10d05c518b7a24"
+  integrity sha512-zmaFnYVBtfpF8bGRYxgPeVAlXB7N3On8rjBE2ROc6wOpTPpzRWaiHo6KkbJMvlH07CH33uks/TEb6kuMMn8q6A==
 
 elliptic@^6.0.0:
   version "6.5.2"
@@ -6571,7 +6579,7 @@ jquery.easing@^1.4.1:
   resolved "https://registry.yarnpkg.com/jquery.easing/-/jquery.easing-1.4.1.tgz#47982c5836bd758fd48494923c4a101ef6e93e3b"
   integrity sha1-R5gsWDa9dY/UhJSSPEoQHvbpPjs=
 
-jquery@3.4.1, jquery@>=1.7:
+jquery@3.4.1, jquery@>=1.10, jquery@>=1.7:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
@@ -7368,7 +7376,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.10.2:
+moment@^2.10.2, moment@^2.9.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
caused by https://github.com/athenianco/athenian-webapp/pull/104#discussion_r390524614

This addresses the suggestion made by https://github.com/athenianco/athenian-webapp/pull/104#discussion_r390524614, importing the styles from [`daterangepicker/blob/master/daterangepicker.css`](https://github.com/dangrossman/daterangepicker/blob/master/daterangepicker.css) and overriding only what was different between that one and the older [`src/sass/components/_datepicker.scss`](https://github.com/athenianco/athenian-webapp/blob/a053537b744ebc578440c664f452d1404835256a/src/sass/components/_datepicker.scss)
