### PR TITLE
Better separation between the summary and the insights section

### DIFF
--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -13,7 +13,7 @@ import { palette } from 'js/res/palette';
 
 import FilledAreaChart from 'js/components/charts/FilledAreaChart';
 
-export default ({ conf, metrics, children }) => {
+export default ({ conf, children }) => {
   return (
     <div>
       <SummaryMetric
@@ -32,21 +32,24 @@ export default ({ conf, metrics, children }) => {
       >
         {children}
       </SummaryMetric>
-      {
-        metrics.map((chart, i) => {
-          return <Metric key={i}
-            title={chart.title}
-            chart={
-              <TimeSeries data={chart.data}
-                color={chart.color} />
-            }
-            insights={chart.insights}>
-          </Metric>;
-        })
-      }
     </div>
   );
 }
+
+export const Insights = ({metrics}) => (
+    <>{
+        metrics.map((chart, i) => (
+            <Metric key={i}
+                    title={chart.title}
+                    chart={
+                        <TimeSeries data={chart.data}
+                                    color={chart.color} />
+                    }
+                    insights={chart.insights}>
+            </Metric>
+        ))
+    }</>
+);
 
 const SummaryMetric = ({ data, chart, children }) => {
   return (

--- a/src/js/pages/pipeline/Overview.jsx
+++ b/src/js/pages/pipeline/Overview.jsx
@@ -29,7 +29,6 @@ export default () => {
         {leadtimeContext.avg ? (
             <StageMetrics
                 conf={leadtimeContext}
-                metrics={[]}
             >
                 {stagesContext.map((stage, i) => stage.leadTimePercentage ? (
                     <div key={i}>

--- a/src/js/pages/pipeline/Stage.jsx
+++ b/src/js/pages/pipeline/Stage.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
-import StageMetrics, { StageSummaryKPI } from 'js/components/pipeline/StageMetrics';
+import StageMetrics, { StageSummaryKPI, Insights } from 'js/components/pipeline/StageMetrics';
 
 import { pipelineStagesConf, getStage } from 'js/pages/pipeline/Pipeline';
-
 import { useBreadcrumbsContext } from 'js/context/Breadcrumbs';
 import { useFiltersContext } from 'js/context/Filters';
 import { usePipelineContext } from 'js/context/Pipeline';
@@ -30,7 +29,7 @@ export default () => {
 
     useBreadcrumbsContext(links);
 
-    const { dateInterval, repositories, contributors } = useFiltersContext()
+    const { dateInterval, repositories, contributors } = useFiltersContext();
 
     useEffect(() => {
         if (!repositories || !repositories.length) {
@@ -45,14 +44,16 @@ export default () => {
         return <p>{stageSlug} is not a valid pipeline stage.</p>;
     }
 
+    if (!activeStage) {
+        return null;
+    }
+
     return (
-        activeStage ? (
-            <StageMetrics
-                metrics={stageChartsState}
-                conf={activeStage}
-            >
-                <StageSummaryKPI data={activeStage.summary(activeStage, prsContext, dateInterval)} />
-            </StageMetrics>
-        ) : null
+        <>
+          <StageMetrics conf={activeStage}>
+            <StageSummaryKPI data={activeStage.summary(activeStage, prsContext, dateInterval)} />
+          </StageMetrics>
+          <Insights metrics={stageChartsState}/>
+        </>
     );
 };


### PR DESCRIPTION
The purpose of this PR is to reduce future conflicts. Since @dpordomingo you're going to add the `Insights` tab and I'm going to implement the charts inside that tab, I'd rather better split the summary block from the insights one.

So that I'll work on the Insights component and on the other hand you're free to move it when you'll implement the tab mechanism.