### PR TITLE
Redirect the user to the home on loging.

### DIFF
--- a/src/js/pages/auth/Login.jsx
+++ b/src/js/pages/auth/Login.jsx
@@ -26,7 +26,7 @@ export default () => {
   }
 
   const appState = {
-    targetUrl: '/waiting',
+    targetUrl: '/',
   };
 
   if (location.state && location.state.inviteLink) {


### PR DESCRIPTION
Redirect the user to the home on loging instead of to the waiting page because it is not yet ready to be used.