### PR TITLE
Count releases

### DIFF
--- a/docs/SummaryMetrics.md
+++ b/docs/SummaryMetrics.md
@@ -56,14 +56,13 @@ Design doc at https://docs.google.com/document/d/1DXLVz4L1Ag9sOUMAKdRRgVh1fk6peU
 ## Release
 - Released PRs: Pull Requests Released (PRs part of releases that happened during the time period selected)
   ```
-  prs.filter(pr.stage=done&&pr.merged).count
+  prs.filter(pr.release_url)
   ```
 - Releases:
   ```
-  NOT-POSSIBLE; Should come from upcoming /releases endpoint
+  prs.filter(pr.release_url).release_url.distinct.count
   ```
 - Repos: Where a release happened
   ```
-  prs.filter(pr.stage=done&&pr.merged).repos.distinct.count
+  prs.filter(pr.release_url).repos.distinct.count
   ```
-

--- a/src/js/pages/pipeline/Pipeline.jsx
+++ b/src/js/pages/pipeline/Pipeline.jsx
@@ -107,12 +107,13 @@ export const pipelineStagesConf = [
         },
         prs: prs => prs.filter(pr => pr.stage === 'release' || pr.stage === 'done'),
         summary: (stage, prs) => {
-            const releasedPRs = prs.filter(pr => pr.stage === 'done' && pr.merged);
+            const releasedPRs = prs.filter(pr => pr.release_url);
+            const releases = distinct(releasedPRs, pr => pr.release_url);
             const repos = distinct(releasedPRs, pr => pr.repository);
             return [
                 ['proportion of the lead time', number.percentage(stage.leadTimePercentage)],
                 ['pull requests released', releasedPRs.length],
-                ['releases', 'TODO'], // TODO(dpordomingo): NOT-POSSIBLE; Should come from upcoming `/releases` endpoint
+                ['releases', releases.length],
                 ['repositories', repos.length],
             ];
         },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2437584/77125540-6a2fe480-6a46-11ea-8ff6-5bbb771970ae.png)

In order to count releases for the given date interval, repos and devs, they're counted the distinct number of `release_url` of all the PRs returned for the same date interval, repos and devs, where `pr.release_url` is the URL of the earliest release that includes the PR.