### PR TITLE
Implement accept/cancel buttons in the date filter

### DIFF
--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -13,5 +13,10 @@
         &:focus {
             color: $white;
         }
+
+        &.btn-disabled {
+            @extend .btn-dark;
+            opacity: .2;
+        }
     }
 }


### PR DESCRIPTION
caused by https://github.com/athenianco/athenian-webapp/pull/135#issuecomment-602519292
required by [[ENG-355]]

This PR adds the proper behavior to the already existent `close` and `apply` data filter buttons; the behavior agreed with @warenlg is:

- click outside -> (keep current behavior) if the filter is valid, apply; otherwise, avoid closing.
- click in cancel -> closes the filter without applying any change.
- click in apply -> (enabled only if the filter is valid) applies the new filter.

If the filter is not valid (startDate and endDate are not both valid), the `apply` button is disabled as shown below:

![image](https://user-images.githubusercontent.com/2437584/77388368-2e6f8480-6d90-11ea-995f-b752eeff7c9a.png)



[ENG-355]: https://athenianco.atlassian.net/browse/ENG-355