### PR TITLE
Adding a hover effect to the PR links

### DIFF
--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -153,6 +153,10 @@
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
+
+        a:hover {
+            text-decoration: underline !important;
+        }
     }
 
     .table-creators {


### PR DESCRIPTION
This PR is related to the ticket [#ENG-409](https://athenianco.atlassian.net/browse/ENG-409) and it adds an underline hover effect to the PR links on the tables.

![image](https://user-images.githubusercontent.com/14981468/77535872-a9719180-6e9b-11ea-85ed-f5efaf2befb2.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>