### PR TITLE
Let the user to decide for any node >= v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "13.*"
+    "node": ">=12"
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.6.3",


### PR DESCRIPTION
The webapp will still be compiled as a `node:13.7-alpine` container,
and tests will run in Travis under `node v13 engine.
