### PR TITLE
Enhance PR tables

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -64,24 +64,30 @@ export default ({ data }) => {
                     title: '',
                     className: 'pr-merged',
                     render: (_, type, row) => {
-                        let pic;
+                        let pic, sort;
                         switch (row.status) {
                             case prStatus.MERGED:
                                 pic = '<i title="merged" class="fa fas fa-code-branch text-merge fa-rotate-180"></i>';
+                                sort = 2;
                                 break;
                             case prStatus.CLOSED:
                                 pic = '<i title="closed" class="icon-pull-request text-danger"></i>';
+                                sort = 3;
                                 break;
                             case prStatus.OPENED:
                                 pic = '<i title="opened" class="icon-pull-request text-success"></i>';
+                                sort = 1;
                                 break;
                         }
 
                         switch (type) {
                             case 'display':
                                 return pic;
-                            default:
-                                return status;
+                            case 'filter':
+                                return `status:${row.status}`;
+                            case 'type':
+                            case 'sort':
+                                return sort;
                         }
                     },
                 },
@@ -102,10 +108,11 @@ export default ({ data }) => {
                                         <span>${dateTime.ago(row.created)} ago</span></div>
                                     </div>
                                 `;
+                            case 'filter':
+                                return row.title + ` number:${row.number} ` + (row.authors.map(user => `author:${github.userName(user)}`).join(' '));
+                            case 'type':
                             case 'sort':
                                 return row.number;
-                            default:
-                                return row.title + ' ' + (row.authors.map(github.userName).join(' '));
                         }
                     },
                 }, {
@@ -121,8 +128,11 @@ export default ({ data }) => {
                                     <span class="align-middle text-success mr-1">+${number.si(row.size_added)}</span>
                                     <span class="align-middle text-danger">-${number.si(row.size_removed)}</span>
                                 `;
-                            default:
-                                return row['files_changed'];
+                            case 'filter':
+                                return '';
+                            case 'type':
+                            case 'sort':
+                                return row.size_added + row.size_removed;
                         }
                     },
                 }, {
@@ -133,7 +143,10 @@ export default ({ data }) => {
                         switch (type) {
                             case 'display':
                                 return `<i class="fa far fa-comment-alt"></i>${row.comments + row.review_comments}`;
-                            default:
+                            case 'filter':
+                                return '';
+                            case 'type':
+                            case 'sort':
                                 return row['comments'] + row['review_comments'];
                         }
                     },
@@ -144,10 +157,11 @@ export default ({ data }) => {
                         switch (type) {
                             case 'display':
                                 return row.commentersReviewers.map(userImage(users)).join(' ');
+                            case 'filter':
+                                return row.commentersReviewers.map(user => `participant:${github.userName(user)}`).join(' ');
+                            case 'type':
                             case 'sort':
                                 return row.commentersReviewers.length;
-                            default:
-                                return row.commentersReviewers.map(userImage(users)).join(' ');
                         }
                     },
                 }, {
@@ -161,7 +175,10 @@ export default ({ data }) => {
                                     return row.closed ? dateTime.interval(row.created, row.closed) : '';
                                 }
                                 return '';
-                            default:
+                            case 'filter':
+                                return '';
+                            case 'type':
+                            case 'sort':
                                 if (row.stage === 'release' || row.stage === 'done') {
                                     return row.closed ? row.closed - row.created : Number.MAX_VALUE;
                                 }

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -5,6 +5,7 @@ import 'datatables.net-bs4';
 import 'datatables.net-bs4/css/dataTables.bootstrap4.css';
 
 import { dateTime, github, number } from 'js/services/format';
+import { PR_STATUS as prStatus } from 'js/services/prHelpers'
 
 const userImage = users => user => {
     if (users[user] && users[user].avatar) {
@@ -63,16 +64,17 @@ export default ({ data }) => {
                     title: '',
                     className: 'pr-merged',
                     render: (_, type, row) => {
-                        let pic, status;
-                        if (row.merged) {
-                            pic = '<i title="merged" class="fa fas fa-code-branch text-merge fa-rotate-180"></i>';
-                            status = 'merged';
-                        } else if (row.stage === 'wip' || row.stage === 'review' || row.stage === 'merge') {
-                            pic = '<i title="opened" class="icon-pull-request text-success"></i>';
-                            status = 'opened';
-                        } else {
-                            pic = '<i title="closed" class="icon-pull-request text-danger"></i>';
-                            status = 'closed';
+                        let pic;
+                        switch (row.status) {
+                            case prStatus.MERGED:
+                                pic = '<i title="merged" class="fa fas fa-code-branch text-merge fa-rotate-180"></i>';
+                                break;
+                            case prStatus.CLOSED:
+                                pic = '<i title="closed" class="icon-pull-request text-danger"></i>';
+                                break;
+                            case prStatus.OPENED:
+                                pic = '<i title="opened" class="icon-pull-request text-success"></i>';
+                                break;
                         }
 
                         switch (type) {

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -171,18 +171,12 @@ export default ({ data }) => {
                     render: (_, type, row) => {
                         switch (type) {
                             case 'display':
-                                if (row.stage === 'release' || row.stage === 'done') {
-                                    return row.closed ? dateTime.interval(row.created, row.closed) : '';
-                                }
-                                return '';
+                                return dateTime.interval(row.created, row.closed || new Date());
                             case 'filter':
                                 return '';
                             case 'type':
                             case 'sort':
-                                if (row.stage === 'release' || row.stage === 'done') {
-                                    return row.closed ? row.closed - row.created : Number.MAX_VALUE;
-                                }
-                                return Number.MAX_VALUE;
+                                return (row.closed || new Date()) - row.created;
                         }
                     },
                 }, {

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -59,6 +59,16 @@ export default ({ data }) => {
             },
             fixedHeader: true,
             data: prs,
+            columnDefs: [
+                { "width": "50px", "targets": 0 },  //status
+                { "width": "130px", "targets": 2 }, //changes
+                { "width": "65px", "targets": 3 },  //comments
+                { "width": "130px", "targets": 4 }, //participants
+                { "width": "70px", "targets": 5 },  //age
+                { "width": "80px", "targets": 6 },  //stage
+                { "width": "100px", "targets": 7 }, //events
+                { "width": "80px", "targets": 8 },  //completed
+            ],
             columns: [
                 {
                     title: '',
@@ -190,6 +200,18 @@ export default ({ data }) => {
                                 return row.stage;
                         }
                     },
+                }, {
+                    title: 'Events',
+                    className: 'pr-events align-middle text-center',
+                    render: (_, __, row) => {
+                        return row.events.map(stage => stage.replace('_happened', '')).join(', ');
+                    },
+                }, {
+                    title: 'Completed',
+                    className: 'pr-completed align-middle text-center',
+                    render: (_, __, row) => {
+                        return row.completedStages.map(stage => stage.replace('-complete', '')).join(', ');
+                    },
                 },
             ],
         });
@@ -205,7 +227,7 @@ export default ({ data }) => {
 
     return (
         <div className="table-responsive mb-4">
-            <table className="table table-bordered" id="dataTable" width="100%" cellSpacing="0" />
+            <table className="table table-bordered" id="dataTable" width="100%" cellSpacing="0" style={{ tableLayout: 'fixed' }} />
         </div>
     );
 }

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -81,7 +81,7 @@ export const getContributors = (token, userAccount, from, to, repos) => {
   const filter = new FilterContribsOrReposRequest(userAccount, from, to);
   filter.in = repos;
   return api.filterContributors({ body: filter })
-        .then(contribs => contribs.map(c => c.login));
+    .then(contribs => contribs.map(c => c.login));
 };
 
 export const getMetrics = (api, accountId, dateInterval, repos, contributors) => {
@@ -158,10 +158,10 @@ export const getMetrics = (api, accountId, dateInterval, repos, contributors) =>
 
 // DEPRECATED: use `fetchPRsMetrics` instead
 const fetchApiMetricsLine = (api, metrics, accountId, dateInterval = { from: null, to: null }, repos = [], contributors = []) => {
-    return fetchPRsMetrics(api, accountId, 'week', dateInterval, metrics, {
-        repositories: repos,
-        developers: contributors
-    });
+  return fetchPRsMetrics(api, accountId, 'week', dateInterval, metrics, {
+    repositories: repos,
+    developers: contributors
+  });
 };
 
 export const getInvitation = async (token, accountID) => {
@@ -184,58 +184,58 @@ export const fetchApi = (token, apiCall, ...args) => {
 };
 
 export const fetchPRsMetrics = async (
-    api, accountID,
-    granularity,
-    dateInterval,
-    metrics = [],
-    filter = { repositories: [], developers: [] },
-    groupBy
+  api, accountID,
+  granularity,
+  dateInterval,
+  metrics = [],
+  filter = { repositories: [], developers: [] },
+  groupBy
 ) => {
-    const metricIDs = new PullRequestMetricID();
-    const forSet = buildForSet(filter, groupBy);
-    const body = new PullRequestMetricsRequest(
-        forSet, metrics.map(m => metricIDs[m]),
-        dateTime.ymd(dateInterval.from),
-        dateTime.ymd(dateInterval.to),
-        granularity, accountID
-    );
+  const metricIDs = new PullRequestMetricID();
+  const forSet = buildForSet(filter, groupBy);
+  const body = new PullRequestMetricsRequest(
+    forSet, metrics.map(m => metricIDs[m]),
+    dateTime.ymd(dateInterval.from),
+    dateTime.ymd(dateInterval.to),
+    granularity, accountID
+  );
 
-    return api.calcMetricsPrLinear(body);
+  return api.calcMetricsPrLinear(body);
 };
 
 export const fetchDevsMetrics = async (
-    api, accountID,
-    dateInterval,
-    metrics = [],
-    filter = { repositories: [], developers: [] },
-    groupBy
+  api, accountID,
+  dateInterval,
+  metrics = [],
+  filter = { repositories: [], developers: [] },
+  groupBy
 ) => {
-    const metricIDs = new DeveloperMetricID();
-    const forSet = buildForSet(filter, groupBy);
-    const body = new DeveloperMetricsRequest(
-        forSet, metrics.map(m => metricIDs[m]),
-        dateTime.ymd(dateInterval.from),
-        dateTime.ymd(dateInterval.to),
-        accountID
-    );
+  const metricIDs = new DeveloperMetricID();
+  const forSet = buildForSet(filter, groupBy);
+  const body = new DeveloperMetricsRequest(
+    forSet, metrics.map(m => metricIDs[m]),
+    dateTime.ymd(dateInterval.from),
+    dateTime.ymd(dateInterval.to),
+    accountID
+  );
 
-    return api.calcMetricsDeveloper(body);
+  return api.calcMetricsDeveloper(body);
 };
 
 
 const buildForSet = (filter, groupBy) => {
-    const forSet = [];
-    if (!groupBy) {
-        forSet.push(ForSet.constructFromObject(filter));
-    } else if (!['repositories', 'developers'].includes(groupBy)) {
-        throw "Invalid groupby";
-    } else {
-        for (const g of filter[groupBy]) {
-            const f = _.clone(filter);
-            f[groupBy] = [g];
-            forSet.push(ForSet.constructFromObject(f));
-        }
+  const forSet = [];
+  if (!groupBy) {
+    forSet.push(ForSet.constructFromObject(filter));
+  } else if (!['repositories', 'developers'].includes(groupBy)) {
+    throw "Invalid groupby";
+  } else {
+    for (const g of filter[groupBy]) {
+      const f = _.clone(filter);
+      f[groupBy] = [g];
+      forSet.push(ForSet.constructFromObject(f));
     }
+  }
 
-    return forSet;
+  return forSet;
 };

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -9,7 +9,8 @@ import {
 import ForSet from 'js/services/api/openapi-client/model/ForSet';
 import PullRequestMetricID from 'js/services/api/openapi-client/model/PullRequestMetricID';
 import DeveloperMetricID from 'js/services/api/openapi-client/model/DeveloperMetricID';
-import { dateTime, github } from 'js/services/format';
+import { dateTime } from 'js/services/format';
+import processPR from 'js/services/prHelpers';
 
 import _ from 'lodash';
 
@@ -32,35 +33,7 @@ export const getPRs = async (token, accountId, dateInterval, repos, contributors
   const prs = await api.filterPrs({ filterPullRequestsRequest: filter });
 
   return {
-    prs: prs.data.map(pr => {
-      const users = pr.participants.reduce((acc, participant) => {
-        if (participant.status.indexOf('author') >= 0) {
-          acc.authors.push(participant.id);
-          return acc;
-        }
-
-        if (participant.status.indexOf('merger') >= 0) {
-          acc.mergers.push(participant.id);
-        }
-
-        if (participant.status.indexOf('reviewer') >= 0 || participant.status.indexOf('commenter') >= 0) {
-          acc.commentersReviewers.push(participant.id);
-        }
-
-        return acc;
-      }, { authors: [], commentersReviewers: [], mergers: [] });
-      return {
-        ...pr,
-        organization: github.repoOrg(pr.repository),
-        repo: github.repoName(pr.repository),
-        created: new Date(pr.created),
-        updated: new Date(pr.updated),
-        closed: new Date(pr.closed),
-        authors: users.authors,
-        mergers: users.mergers,
-        commentersReviewers: users.commentersReviewers
-      }
-    }),
+    prs: prs.data.map(processPR),
     users: (prs.include && prs.include.users) || {},
   };
 };

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -1,20 +1,51 @@
 import { github } from 'js/services/format';
 
+export const PR_STAGE = {
+  WIP: 'wip',
+  REVIEW: 'review',
+  MERGE: 'merge',
+  RELEASE: 'release',
+  DONE: 'done',
+  COMPLETE: {
+    WIP: 'wip-complete',
+    REVIEW: 'review-complete',
+    MERGE: 'merge-complete',
+    RELEASE: 'release-complete',
+  },
+};
+
+export const PR_EVENT = {
+  CREATION: 'created',
+  COMMIT: 'commit_happened',
+  REVIEW_REQUEST: 'review_requested', // Transitions to 'review' Stage
+  REVIEW: 'review_happened',
+  APPROVE: 'approve_happened',        // Transitions to 'merge' Stage
+  MERGE: 'merge_happened',            // Transitions to 'release' Stage
+  RELEASE: 'release_happened',        // Transitions to 'done' Stage
+};
+
 export const PR_STATUS = {
   OPENED: 'opened',
   MERGED: 'merged',
   CLOSED: 'closed',
 };
 
+const realEvents = Object.keys(PR_EVENT).map(eventKey => PR_EVENT[eventKey]);
 
 export default pr => {
+  // TODO(dpordomingo): This won't be needed once 'pr.properties' are split into 'pr.stage' and 'pr.events'
+  const events = extractEvents(pr);
+
+  const completedStages = extractCompletedStages(events);
   const status = extractStatus(pr);
 
   const { authors, mergers, commentersReviewers } = extractParticipantsByKind(pr);
 
   return {
     ...pr,
+    events,
     status,
+    completedStages,
     authors,
     mergers,
     commentersReviewers,
@@ -45,6 +76,15 @@ const extractParticipantsByKind = pr => pr.participants.reduce((acc, participant
   return acc;
 }, { authors: [], commentersReviewers: [], mergers: [] });
 
+const extractEvents = pr => {
+  const events = pr.properties.filter(property => realEvents.indexOf(property) >= 0);
+  if (pr.review_requested) {
+    events.push(PR_EVENT.REVIEW_REQUEST);
+  }
+
+  return events;
+};
+
 const extractStatus = pr => {
   if (pr.merged) {
     return PR_STATUS.MERGED;
@@ -54,3 +94,31 @@ const extractStatus = pr => {
     return PR_STATUS.OPENED;
   }
 };
+
+const extractCompletedStages = events => {
+  if (events.indexOf(PR_EVENT.RELEASE) >= 0) {
+    return [
+      PR_STAGE.COMPLETE.WIP,
+      PR_STAGE.COMPLETE.REVIEW,
+      PR_STAGE.COMPLETE.MERGE,
+      PR_STAGE.COMPLETE.RELEASE
+    ];
+  } else if (events.indexOf(PR_EVENT.MERGE) >= 0) {
+    return [
+      PR_STAGE.COMPLETE.WIP,
+      PR_STAGE.COMPLETE.REVIEW,
+      PR_STAGE.COMPLETE.MERGE,
+    ];
+  } else if (events.indexOf(PR_EVENT.APPROVE) >= 0) {
+    return [
+      PR_STAGE.COMPLETE.WIP,
+      PR_STAGE.COMPLETE.REVIEW,
+    ];
+  } else if (events.indexOf(PR_EVENT.REVIEW_REQUEST) >= 0) {
+    return [
+      PR_STAGE.COMPLETE.WIP,
+    ];
+  }
+
+  return [];
+}

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -22,7 +22,9 @@ export default pr => {
     repo: github.repoName(pr.repository),
     created: new Date(pr.created),
     updated: new Date(pr.updated),
-    closed: new Date(pr.closed),
+    closed: pr.closed && new Date(pr.closed),
+    merged: pr.merged && new Date(pr.merged),
+    released: pr.released && new Date(pr.released),
   }
 };
 

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -1,0 +1,54 @@
+import { github } from 'js/services/format';
+
+export const PR_STATUS = {
+  OPENED: 'opened',
+  MERGED: 'merged',
+  CLOSED: 'closed',
+};
+
+
+export default pr => {
+  const status = extractStatus(pr);
+
+  const { authors, mergers, commentersReviewers } = extractParticipantsByKind(pr);
+
+  return {
+    ...pr,
+    status,
+    authors,
+    mergers,
+    commentersReviewers,
+    organization: github.repoOrg(pr.repository),
+    repo: github.repoName(pr.repository),
+    created: new Date(pr.created),
+    updated: new Date(pr.updated),
+    closed: new Date(pr.closed),
+  }
+};
+
+const extractParticipantsByKind = pr => pr.participants.reduce((acc, participant) => {
+  if (participant.status.indexOf('author') >= 0) {
+    acc.authors.push(participant.id);
+    return acc;
+  }
+
+  if (participant.status.indexOf('merger') >= 0) {
+    acc.mergers.push(participant.id);
+  }
+
+  if (participant.status.indexOf('reviewer') >= 0 || participant.status.indexOf('commenter') >= 0) {
+    acc.commentersReviewers.push(participant.id);
+  }
+
+  return acc;
+}, { authors: [], commentersReviewers: [], mergers: [] });
+
+const extractStatus = pr => {
+  if (pr.merged) {
+    return PR_STATUS.MERGED;
+  } else if (pr.closed) {
+    return PR_STATUS.CLOSED;
+  } else {
+    return PR_STATUS.OPENED;
+  }
+};


### PR DESCRIPTION
solves [[ENG-382]] Add the PRs stage-complete in each of the 4 tables
solves [[ENG-381]] Age of opened PRs should be `now()-pr.created`

## major changes
- d205a27 solves [[ENG-382]] Add stage-complete into PR tables
- 2a2cf20 solves [[ENG-381]] Enhance Age in PR tables (if the PR has not `closed` date, it assumes `now()`)

## enhancements
- 768f2d4 Enhance filter and sort in PR tables
You can now filter by `status:<opened|merged|closed>`, `number:<PR-number>`, `author:<user>`, `participant:<user>`

## helper
- 182a429 Show PR Events and PR Completed Stages. It will be removed once [[ENG-325]] is released; in the meanwhile, it helps to understand why each PR is listed in each stage, showing events and complete stages.

![image](https://user-images.githubusercontent.com/2437584/77811155-e6ef3e00-7098-11ea-862a-3005b3586c11.png)


[ENG-382]: https://athenianco.atlassian.net/browse/ENG-382
[ENG-381]: https://athenianco.atlassian.net/browse/ENG-381
[ENG-382]: https://athenianco.atlassian.net/browse/ENG-382
[ENG-381]: https://athenianco.atlassian.net/browse/ENG-381
[ENG-325]: https://athenianco.atlassian.net/browse/ENG-325