### PR TITLE
Adding hover effect to the pipeline tabs

### DIFF
--- a/src/sass/components/_pipeline.scss
+++ b/src/sass/components/_pipeline.scss
@@ -97,6 +97,7 @@
         }
 
         .pipeline-thumbnail {
+
             &:hover {
                 background: rgba($white, .5);
             }
@@ -118,6 +119,26 @@
                 }
             }
         }
+    }
+}
+
+.pipeline-thumbnail:hover {
+    transition: border-color 0.3s;
+
+    .wip & {
+        border-color: $color-wip;
+    }
+
+    .review & {
+        border-color: $color-review;
+    }
+
+    .merge & {
+        border-color: $color-merge;
+    }
+
+    .release & {
+        border-color: $color-release;
     }
 }
 


### PR DESCRIPTION
This is related to the ticket [#ENG-440](https://athenianco.atlassian.net/browse/ENG-440).

It adds a colored border to the hover of the pipeline tabs.

![image](https://user-images.githubusercontent.com/14981468/77907012-372cf280-7289-11ea-8559-33d92900d725.png)

![image](https://user-images.githubusercontent.com/14981468/77907040-43b14b00-7289-11ea-81f0-805d9a819d33.png)

![image](https://user-images.githubusercontent.com/14981468/77907060-4c098600-7289-11ea-977b-deed7615a7cd.png)

![image](https://user-images.githubusercontent.com/14981468/77907083-5461c100-7289-11ea-906a-e3b3d6672416.png)
