### PR TITLE
Use stage labels instead of pr stages

### DIFF
--- a/src/js/pages/pipeline/Overview.jsx
+++ b/src/js/pages/pipeline/Overview.jsx
@@ -48,7 +48,7 @@ export default () => {
             {
                 title: 'Pull Requests',
                 badge: prsContext.prs.length,
-                content: <PullRequests data={prsContext} />
+                content: <PullRequests data={prsContext} stage="overview" />
             }
         ]} />
     </>

--- a/src/js/pages/pipeline/Stage.jsx
+++ b/src/js/pages/pipeline/Stage.jsx
@@ -84,7 +84,7 @@ export default () => {
             {
                 title: 'Pull Requests',
                 badge: filteredPRs.prs.length,
-                content: <PullRequests data={filteredPRs} />
+                content: <PullRequests data={filteredPRs} stage={activeStage.stageName} />
             }
         ]} />
     </>;

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -167,6 +167,10 @@
             vertical-align: middle;
         }
     }
+
+    .badge-outlined {
+        width: 100%;
+    }
 }
 
 div.dataTables_wrapper div.dataTables_length select {


### PR DESCRIPTION
solves [[ENG-325]] Label the PRs in each table

As described in the issue discussion, if a PR contains any comment, it will be labeled as `Changes Requested`

Also, if the mouse hovers the PR label, it will appear a tooltip containing the PR stage, events received and completed stages as in the screenshot below.

![screenshot-prs](https://user-images.githubusercontent.com/2437584/77934184-02806180-72b0-11ea-97a6-2a9e0acf3b30.png)
Signed-off-by: David Pordomingo <David.Pordomingo.F@gmail.com>

[ENG-325]: https://athenianco.atlassian.net/browse/ENG-325