### PR TITLE
Adding simple hover effect to the tabs

### DIFF
--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -1,8 +1,13 @@
 .ath-tabs .tab {
     cursor: pointer;
 
-    &.active {
+    &.active,
+    &.active:hover {
         @extend .border-bottom-primary;
         cursor: default;
+    }
+
+    &:hover {
+        border-bottom: 0.25rem solid $at-border-color !important;
     }
 }


### PR DESCRIPTION
This is based on the task [#ENG-457](https://athenianco.atlassian.net/browse/ENG-457) and adds a subtle border to the tabs on hover.

![image](https://user-images.githubusercontent.com/14981468/78048898-ac2c2500-737a-11ea-9080-1440d6eafc49.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>