### PR TITLE
Insights charts tooltips

### DIFF
--- a/src/js/components/charts/Tooltip.jsx
+++ b/src/js/components/charts/Tooltip.jsx
@@ -26,16 +26,16 @@ export default ({value, ...props}) => {
     );
 };
 
-export const onValueChange = (datapoint, eventType, current, setCurrent) => {
+export const onValueChange = (datapoint, eventType, current, setCurrent, blacklist) => {
     console.log(`START: ${eventType}`);
 
-    if (!current ||
-        (current && (datapoint.x.toString() !== current.x.toString() ||
-                          datapoint.y !== current.y))) {
-        console.log('setting datapoint');
-        setCurrent(datapoint);
+    if (current && sameObjects(datapoint, current, blacklist)) {
+        console.log(`END: ${eventType}`);
+        return;
     }
 
+    console.log('setting datapoint');
+    setCurrent(getFilteredObject(datapoint, blacklist));
     console.log(`END: ${eventType}`);
 };
 
@@ -44,3 +44,12 @@ export const onValueReset = (datapoint, eventType, current, setCurrent) => {
     setCurrent(null);
     console.log(`END: ${eventType}`);
 };
+
+const sameObjects = (previous, current, blacklist) => {
+    const filteredPrev = getFilteredObject(previous, blacklist);
+    const filteredCurr = getFilteredObject(current, blacklist);
+
+    return _.isEqual(filteredPrev, filteredCurr);
+};
+
+const getFilteredObject = (obj, blacklist) => _(obj).omit(blacklist).value();

--- a/src/js/components/insights/charts/library/BubbleChart.jsx
+++ b/src/js/components/insights/charts/library/BubbleChart.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { scaleLog } from 'd3-scale';
 
 import _ from 'lodash';
@@ -16,6 +16,7 @@ import {
     DiscreteColorLegend
 } from 'react-vis';
 
+import Tooltip, { onValueChange, onValueReset } from 'js/components/charts/Tooltip';
 
 export default ({title, data, extra}) => (
     <div style={{ background: 'white' }}>
@@ -42,7 +43,7 @@ const formatData = (data, extra) => _(data)
       })
       .value();
 
-const buildSeries = (title, formattedData, extra) => {
+const buildSeries = (title, formattedData, extra, currentHover, setCurrentHover) => {
     const transformer = extra.isLogScale ? logScale : (v) => v;
     let marksSeries;
     if (extra.grouper) {
@@ -60,6 +61,8 @@ const buildSeries = (title, formattedData, extra) => {
                     size: v.size,
                     label: v.label
                 }))}
+                onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
+                onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
               />
           ))
             .value();
@@ -86,6 +89,15 @@ const buildSeries = (title, formattedData, extra) => {
                           )
                       }))
                   }
+                  onValueMouseOver={
+                      (datapoint, event) => onValueChange(
+                          datapoint, "mouseover", currentHover, setCurrentHover,
+                          ['customComponent'])
+                  }
+                  onValueMouseOut={
+                      (datapoint, event) => onValueReset(
+                          datapoint, "mouseout", currentHover, setCurrentHover)
+                  }
                 />
             ];
         } else {
@@ -100,7 +112,10 @@ const buildSeries = (title, formattedData, extra) => {
                       y: transformer(v.y),
                       size: v.size,
                       label: v.label
-                  }))} />
+                  }))}
+                  onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
+                  onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
+                />
             ];
         }
     }
@@ -109,12 +124,15 @@ const buildSeries = (title, formattedData, extra) => {
 };
 
 const BubbleChart = ({ title, data, extra }) => {
+    const [currentHover, setCurrentHover] = useState(null);
+
     if (data.length === 0) {
         return <></>;
     }
 
     const formattedData = formatData(data, extra);
-    const marksSeries = buildSeries(title, formattedData, extra);
+    const marksSeries = buildSeries(title, formattedData, extra,
+                                    currentHover, setCurrentHover);
 
     const legend = _(extra.groups)
           .map(v => ({ title: v.title, color: v.color }))
@@ -139,6 +157,7 @@ const BubbleChart = ({ title, data, extra }) => {
           <YBubbleChartAxis formattedData={formattedData} label={extra.axisLabels.y} />
 
           {marksSeries}
+          {currentHover && <Tooltip value={currentHover} />}
 
         </FlexibleWidthXYPlot>
     );
@@ -165,12 +184,15 @@ const CircleMask = ({id, maskProperties}) => (
 CircleMask.requiresSVG = true;
 
 const BubbleChartLogScale = ({ title, data, extra }) => {
+    const [currentHover, setCurrentHover] = useState(null);
+
     if (data.length === 0) {
         return <></>;
     }
 
     const formattedData = formatData(data, extra);
-    const marksSeries = buildSeries(title, formattedData, extra);
+    const marksSeries = buildSeries(title, formattedData, extra,
+                                    currentHover, setCurrentHover);
 
     const legend = _(extra.groups)
           .map(v => ({ title: v.title, color: v.color }))
@@ -195,6 +217,7 @@ const BubbleChartLogScale = ({ title, data, extra }) => {
           <YBubbleChartLogAxis formattedData={formattedData} label={extra.axisLabels.y} />
 
           {marksSeries}
+          {currentHover && <Tooltip value={currentHover} />}
 
         </FlexibleWidthXYPlot>
     );

--- a/src/js/components/insights/charts/library/HorizontalBarChart.jsx
+++ b/src/js/components/insights/charts/library/HorizontalBarChart.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
     FlexibleWidthXYPlot,
@@ -9,6 +9,8 @@ import {
     DiscreteColorLegend,
 } from 'react-vis';
 
+import Tooltip, { onValueChange, onValueReset } from 'js/components/charts/Tooltip';
+
 import _ from 'lodash';
 
 export default ({title, data, extra}) => (
@@ -18,6 +20,8 @@ export default ({title, data, extra}) => (
 );
 
 const HorizontalBarChart = ({ title, data, extra }) => {
+    const [currentHover, setCurrentHover] = useState(null);
+
     if (data.length === 0) {
         return <></>;
     }
@@ -75,7 +79,11 @@ const HorizontalBarChart = ({ title, data, extra }) => {
                                      data={s.reverse()}
                                      color={extra.series[k].color}
                                      key={k}
-                                     barWidth={extra.barWidth || 0.5}/>).value()}
+                                     barWidth={extra.barWidth || 0.5}
+                                     onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
+                                     onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
+                                   />).value()}
+          {currentHover && <Tooltip value={currentHover} />}
         </FlexibleWidthXYPlot>
     );
 };

--- a/src/js/components/insights/charts/library/TimeSeries.jsx
+++ b/src/js/components/insights/charts/library/TimeSeries.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { dateTime } from 'js/services/format';
 
@@ -14,6 +14,8 @@ import {
     LineSeries,
     MarkSeries
 } from 'react-vis';
+
+import Tooltip, { onValueChange, onValueReset } from 'js/components/charts/Tooltip';
 
 export default ({title, data, extra}) => (
     <div style={{ background: 'white' }}>
@@ -64,6 +66,8 @@ const computeTickValues = (formattedData, maxNumberOfTicks) => {
 };
 
 const TimeSeries = ({ title, data, extra }) => {
+    const [currentHover, setCurrentHover] = useState(null);
+
     if (data.length === 0) {
         return <></>;
     }
@@ -106,6 +110,8 @@ const TimeSeries = ({ title, data, extra }) => {
             strokeWidth={3}
             data={formattedData}
             animation="stiff"
+            onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
+            onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
           />
 
           {referenceData.length > 0 &&
@@ -120,6 +126,8 @@ const TimeSeries = ({ title, data, extra }) => {
              data={referenceData}
              animation="stiff"
            />}
+
+          {currentHover && <Tooltip value={currentHover} />}
         </FlexibleWidthXYPlot>
     );
 };

--- a/src/js/components/insights/charts/library/VerticalBarChart.jsx
+++ b/src/js/components/insights/charts/library/VerticalBarChart.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import _ from 'lodash';
 
@@ -11,6 +11,8 @@ import {
     ChartLabel,
 } from 'react-vis';
 
+import Tooltip, { onValueChange, onValueReset } from 'js/components/charts/Tooltip';
+
 export default ({title, data, extra}) => (
     <div style={{ background: 'white' }}>
       <VerticalBarChart title={title} data={data} extra={extra} />
@@ -18,6 +20,8 @@ export default ({title, data, extra}) => (
 );
 
 const VerticalBarChart = ({ title, data, extra }) => {
+    const [currentHover, setCurrentHover] = useState(null);
+
     if (data.length === 0) {
         return <></>;
     }
@@ -39,8 +43,15 @@ const VerticalBarChart = ({ title, data, extra }) => {
           <YAxis />
           {extra.axisLabels && extra.axisLabels.y && buildChartLabel(extra.axisLabels.y, 'y')}
 
-          <VerticalBarSeries data={formattedData} color={color} barWidth={0.5} />
+          <VerticalBarSeries
+            data={formattedData}
+            color={color}
+            barWidth={0.5}
+            onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
+            onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
+          />
 
+          {currentHover && <Tooltip value={currentHover} />}
         </FlexibleWidthXYPlot>
     );
 };


### PR DESCRIPTION
Attach logic for tooltips to each visualization type by default. The style and the content of the tooltips is out of the scope of this PR. Now we show everything in the datapoint.

## Some screenshots

<img width="770" alt="Screenshot 2020-03-31 at 19 34 13" src="https://user-images.githubusercontent.com/5599208/78057643-5f028000-7387-11ea-846a-4657765ab29e.png">
<img width="736" alt="Screenshot 2020-03-31 at 19 34 20" src="https://user-images.githubusercontent.com/5599208/78057646-60cc4380-7387-11ea-9545-705188c48f4b.png">
<img width="709" alt="Screenshot 2020-03-31 at 19 34 28" src="https://user-images.githubusercontent.com/5599208/78057652-61fd7080-7387-11ea-99e2-f48f9a8d5136.png">
<img width="708" alt="Screenshot 2020-03-31 at 19 34 43" src="https://user-images.githubusercontent.com/5599208/78057653-62960700-7387-11ea-8d70-6dbca0aaafff.png">
<img width="700" alt="Screenshot 2020-03-31 at 19 35 04" src="https://user-images.githubusercontent.com/5599208/78057655-62960700-7387-11ea-8510-74a1cdcc2502.png">
<img width="701" alt="Screenshot 2020-03-31 at 19 36 48" src="https://user-images.githubusercontent.com/5599208/78057658-632e9d80-7387-11ea-9133-719fb75d23c4.png">
<img width="732" alt="Screenshot 2020-03-31 at 19 36 56" src="https://user-images.githubusercontent.com/5599208/78057659-632e9d80-7387-11ea-8b15-0fd694de84f5.png">
