### PR TITLE
Enhance badges

### DIFF
--- a/src/js/components/pipeline/MainMetrics.jsx
+++ b/src/js/components/pipeline/MainMetrics.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Badge from 'js/components/ui/Badge';
+import Badge, { NEGATIVE_IS_BETTER, POSITIVE_IS_BETTER } from 'js/components/ui/Badge';
 import { BigNumber } from 'js/components/ui/Typography';
 import Info from 'js/components/ui/Info';
 
@@ -17,12 +17,14 @@ export default ({
             <div className="col-md-3">
                 <MainMetric title="Lead time" value={leadTimeAvg && dateTime.human(leadTimeAvg)} variation={leadTimeVariation}
                     hint="Average of time elapsed between the creation of the 1st commit in the Pull Requests within the active filters, and the code being used in production"
+                    negativeIsBetter
                 />
             </div>
             <div className="col-md-3">
                 <MainMetric
                     title="Cycle time" value={cycleTimeAvg} variation={cycleTimeVariation}
                     hint="The sum of each stage average time from start to finish"
+                    negativeIsBetter
                 />
             </div>
             <div className="col-md-3">
@@ -40,7 +42,7 @@ export default ({
     );
 };
 
-const MainMetric = ({ title, hint, value, variation }) => (
+const MainMetric = ({ title, hint, value, variation, negativeIsBetter = false }) => (
     <div className="card">
         <div className="card-body py-2 px-3">
             <div className="card-title mb-0">
@@ -51,7 +53,11 @@ const MainMetric = ({ title, hint, value, variation }) => (
                     </div>
                     <div className="d-flex align-items-center">
                         <BigNumber content={value} />
-                        {value ? <Badge value={number.round(variation)} trend className="ml-4" /> : ''}
+                        {value ? <Badge
+                            value={number.round(variation)}
+                            trend={negativeIsBetter ? NEGATIVE_IS_BETTER : POSITIVE_IS_BETTER}
+                            className="ml-4"
+                        /> : ''}
                     </div>
                 </div>
             </div>

--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -10,6 +10,7 @@ import { dateTime, number } from 'js/services/format';
 import { palette } from 'js/res/palette';
 
 import FilledAreaChart from 'js/components/charts/FilledAreaChart';
+import { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 
 export const SummaryMetrics = ({ conf, children }) => {
   return (
@@ -21,7 +22,7 @@ export const SummaryMetrics = ({ conf, children }) => {
             <div className="pl-2">
               <div className="font-weight-bold mt-4 mb-3 pb-2 border-bottom">
                 <BigNumber content={dateTime.human(conf.avg)} isXL />
-                <Badge value={number.round(conf.variation)} className="ml-2" trend />
+                <Badge value={number.round(conf.variation)} className="ml-2" trend={NEGATIVE_IS_BETTER} />
               </div>
               <div>
                 {children}

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import classnames from 'classnames';
 
 import CleanAreaChart, { vertical } from 'js/components/charts/CleanAreaChart';
-import Badge from 'js/components/ui/Badge';
+import Badge, { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 import { BigNumber, SmallTitle } from 'js/components/ui/Typography';
 import Info from 'js/components/ui/Info'
 
@@ -55,7 +55,7 @@ const Stage = ({ title, text, hint, badge, variation, color, data, active, onCli
                 <div className="row no-gutters card-text">
                     <div className="col-5">
                         <BigNumber content={text} className="mb-1 w-100" />
-                        {text ? <Badge trend value={number.round(variation)} /> : ''}
+                        {text ? <Badge trend={NEGATIVE_IS_BETTER} value={number.round(variation)} /> : ''}
                     </div>
                     <div className="col-7 pl-2" style={{ height: 55 }}>
                         {data && <PipelineCardMiniChart data={data} color={color} active={active} />}

--- a/src/js/components/ui/Badge.jsx
+++ b/src/js/components/ui/Badge.jsx
@@ -4,17 +4,20 @@ import classnames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faCaretUp, faEquals } from '@fortawesome/free-solid-svg-icons';
 
-export default ({ value, trend, className }) => {
+export const POSITIVE_IS_BETTER = 'positive-variation-is-better'; // default
+export const NEGATIVE_IS_BETTER = 'negative-variation-is-better';
+
+export default ({ value, trend = POSITIVE_IS_BETTER, className }) => {
   const commonClasses = ['badge', 'font-weight-normal', 'align-middle', 'd-inline-block'];
   let customClasses, icon;
   let suffix = '%';
   if (!trend) {
     customClasses = ['badge-pill', 'badge-secondary', 'py-1', 'px-2'];
   } else if (value < 0) {
-    customClasses = ['badge-danger'];
+    customClasses = [trend === NEGATIVE_IS_BETTER ? 'badge-success' : 'badge-danger'];
     icon = faCaretDown;
   } else if (value > 0) {
-    customClasses = ['badge-success'];
+    customClasses = [trend === NEGATIVE_IS_BETTER ? 'badge-danger' : 'badge-success'];
     icon = faCaretUp;
   } else {
     customClasses = ['badge-secondary'];

--- a/src/js/components/ui/Badge.jsx
+++ b/src/js/components/ui/Badge.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import classnames from 'classnames';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretDown, faCaretUp, faEquals } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
 
 export const POSITIVE_IS_BETTER = 'positive-variation-is-better'; // default
 export const NEGATIVE_IS_BETTER = 'negative-variation-is-better';
 
-export default ({ value, trend = POSITIVE_IS_BETTER, className }) => {
+export default ({ value, trend = false, className }) => {
   const commonClasses = ['badge', 'font-weight-normal', 'align-middle', 'd-inline-block'];
   let customClasses, icon;
   let suffix = '%';
@@ -20,17 +20,15 @@ export default ({ value, trend = POSITIVE_IS_BETTER, className }) => {
     customClasses = [trend === NEGATIVE_IS_BETTER ? 'badge-danger' : 'badge-success'];
     icon = faCaretUp;
   } else {
-    customClasses = ['badge-secondary'];
-    icon = faEquals;
-    suffix = '';
+    return '';
   }
 
   return (
-    <span className={classnames('badge', className, ...commonClasses, ...customClasses)}>
+    <span className={classnames(className, ...commonClasses, ...customClasses)}>
       {trend ? (
         <>
           <FontAwesomeIcon icon={icon} className="align-bottom" />
-          {value ? <span className="ml-1">{Math.abs(value)}{suffix}</span> : ''}
+          <span className="ml-1">{Math.abs(value)}{suffix}</span>
         </>
       ) : (
           <>{value}</>


### PR DESCRIPTION
- 128d75b [[ENG-321]] Configure positive/negative variation
- 5e75de4 [[ENG-376]] Omit variation badge if it's zero

Main change:
It can be selected the meaning of the variation, being good  (green) if less or greater than `0`
- `<Badge value={3} />` &rarr; regular badge, no variation
- `<Badge value={3} trend />` &rarr; variation badge (default), positive is good (green)
- `<Badge value={3} trend={POSITIVE_IS_BETTER} />` &rarr; variation badge, positive is good (green)
- `<Badge value={3} trend={NEGATIVE_IS_BETTER} />` &rarr; variation badge, positive is bad (red)

![image](https://user-images.githubusercontent.com/2437584/78128723-adab2b00-7416-11ea-87a0-1f8f0a43f7bd.png)


[ENG-321]: https://athenianco.atlassian.net/browse/ENG-321
[ENG-376]: https://athenianco.atlassian.net/browse/ENG-376