### PR TITLE
Let 'PullRequest|Created' 2nd column sort by 'pr.created' date

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -103,7 +103,7 @@ export default ({ stage, data }) => {
                     },
                 },
                 {
-                    title: 'Pull Requests',
+                    title: 'Pull Requests | Created',
                     className: 'pr-main',
                     render: (_, type, row) => {
                         switch (type) {
@@ -124,7 +124,7 @@ export default ({ stage, data }) => {
                             case 'type':
                             case 'sort':
                             default:
-                                return row.number;
+                                return row.created;
                         }
                     },
                 }, {


### PR DESCRIPTION
When clicking in the header of the second column of the PRs table (`PullRequest|Created`), the PRs will be sorted by  its `created` date