### PR TITLE
Fix variation 1st review kpi

### DIFF
--- a/src/js/components/insights/KPI.jsx
+++ b/src/js/components/insights/KPI.jsx
@@ -11,6 +11,7 @@ import { number } from 'js/services/format';
   - params: object{
         value: number (required)
         variation: number (optional)
+        variationMeaning: NEGATIVE_IS_BETTER | POSITIVE_IS_BETTER (optional, default:POSITIVE_IS_BETTER)
         unit: string | object{
             singular: string
             plural: string
@@ -38,7 +39,7 @@ import { number } from 'js/services/format';
 export const SimpleKPI = ({params}) => (
     <div className="font-weight-bold">
       <BigNumber content={buildContent(params.value, getUnit(params.value, params.unit))} />
-      {params.variation && <Badge value={number.round(params.variation)} trend className="ml-2" />}
+      {params.variation && <Badge value={number.round(params.variation)} trend={params.variationMeaning} className="ml-2" />}
     </div>
 );
 

--- a/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
+++ b/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
@@ -1,5 +1,6 @@
 import { SimpleKPI } from 'js/components/insights/KPI';
 import TimeSeries from 'js/components/insights/charts/library/TimeSeries';
+import { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 
 import { fetchPRsMetrics } from 'js/services/api/index';
 
@@ -113,6 +114,7 @@ const waitTimeFirstReview = {
                             params: {
                                 value: computed.KPIsData.avgWaitingTime.value,
                                 variation: computed.KPIsData.avgWaitingTime.variation,
+                                variationMeaning: NEGATIVE_IS_BETTER,
                                 unit: {
                                     singular: 'hour',
                                     plural: 'hours'
@@ -125,6 +127,7 @@ const waitTimeFirstReview = {
                             params: {
                                 value: computed.KPIsData.overallProportion.value.toFixed(2),
                                 variation: computed.KPIsData.overallProportion.variation,
+                                variationMeaning: NEGATIVE_IS_BETTER,
                                 unit: '%'
                             }
                         },


### PR DESCRIPTION
required by [[ENG-433]]

`Average Waiting Time for 1st review` and `Proportion of the Cycle Time` KPIs of `Wait Time for 1st Review` chart, seems to be good when decreasing, and bad if increasing, so this PR changes badge color following that rule.

![image](https://user-images.githubusercontent.com/2437584/78303307-b433c280-753c-11ea-85a6-5d9b8748dce5.png)

[ENG-433]: https://athenianco.atlassian.net/browse/ENG-433