### PR TITLE
Count stage-completed in pipeline thumbs badges

### DIFF
--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -10,7 +10,6 @@ import Info from 'js/components/ui/Info'
 import { dateTime, number } from 'js/services/format';
 
 export default ({ prs, stages, activeCard }) => {
-    //TODO(dpordomingo): stage.badge should count the stage-complete PRs, not the stage-pending ones. It should be obtained from the API
     return (
         <div className="row mt-4 mb-4 align-items-end pipeline-thumbnails">
             {
@@ -27,7 +26,7 @@ export default ({ prs, stages, activeCard }) => {
                                     color={card.color}
                                     data={card.data}
                                     active={activeCard === card.slug}
-                                    badge={prs.filter(pr => pr.stage === card.stageName).length}
+                                    badge={card.stageCompleteCount(prs)}
                                 >
                                 </Stage>
                             </Link>

--- a/src/js/pages/pipeline/Pipeline.jsx
+++ b/src/js/pages/pipeline/Pipeline.jsx
@@ -37,6 +37,7 @@ export const pipelineStagesConf = [
             after: 'Review Requested',
         },
         prs: prs => prs.filter(pr => pr.stage === prStage.WIP || pr.completedStages.indexOf(prStageComplete.WIP) >= 0),
+        stageCompleteCount: prs => prs.filter(pr => pr.completedStages.indexOf(prStageComplete.WIP) >= 0).length,
         summary: (stage, prs, dateInterval) => {
             const createdPrs = prs.filter(pr => dateInterval.from < pr.created && pr.created < dateInterval.to);
             const authors = distinct(createdPrs, pr => pr.authors);
@@ -60,6 +61,7 @@ export const pipelineStagesConf = [
             after: 'Approved',
         },
         prs: prs => prs.filter(pr => pr.stage === prStage.REVIEW || pr.completedStages.indexOf(prStageComplete.REVIEW) >= 0),
+        stageCompleteCount: prs => prs.filter(pr => pr.completedStages.indexOf(prStageComplete.REVIEW) >= 0).length,
         summary: (stage, prs) => {
             const reviewAndReviewCompletePRs = prs.filter(pr => pr.stage !== 'wip');
             const reviewed = reviewAndReviewCompletePRs.filter(pr => pr.comments || pr.review_comments)
@@ -84,7 +86,9 @@ export const pipelineStagesConf = [
             after: 'Merged',
         },
         prs: prs => prs.filter(pr => pr.stage === prStage.MERGE || pr.completedStages.indexOf(prStageComplete.MERGE) >= 0),
+        stageCompleteCount: prs => prs.filter(pr => pr.completedStages.indexOf(prStageComplete.MERGE) >= 0).length,
         summary: (stage, prs) => {
+            debugger;
             const mergedPRs = prs.filter(pr => pr.merged);
             const mergerers = distinct(mergedPRs, pr => pr.mergers);
             const repos = distinct(mergedPRs, pr => pr.repository);
@@ -107,6 +111,7 @@ export const pipelineStagesConf = [
             after: 'Released',
         },
         prs: prs => prs.filter(pr => pr.stage === prStage.RELEASE || pr.completedStages.indexOf(prStageComplete.RELEASE) >= 0),
+        stageCompleteCount: prs => prs.filter(pr => pr.completedStages.indexOf(prStageComplete.RELEASE) >= 0).length,
         summary: (stage, prs) => {
             const releasedPRs = prs.filter(pr => pr.release_url);
             const releases = distinct(releasedPRs, pr => pr.release_url);


### PR DESCRIPTION
closes [[ENG-405]]

Badges in pipeline thumbs will count `stage-complete` PRs instead of those PRs in `stage`

[ENG-405]: https://athenianco.atlassian.net/browse/ENG-405