### PR TITLE
Prepare labels to use their own colors

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -5,7 +5,7 @@ import 'datatables.net-bs4';
 import 'datatables.net-bs4/css/dataTables.bootstrap4.css';
 
 import { dateTime, github, number } from 'js/services/format';
-import { PR_STATUS as prStatus, prLabel } from 'js/services/prHelpers'
+import { prLabel, PR_STATUS as prStatus, PR_LABELS_CLASSNAMES as prLabelClasses } from 'js/services/prHelpers'
 
 const userImage = users => user => {
     if (users[user] && users[user].avatar) {
@@ -206,7 +206,7 @@ export default ({ stage, data }) => {
                                     `events:[${row.events.map(stage => stage.replace('_happened', '')).join(', ')}],\n` +
                                     `stage-completes:[${row.completedStages.map(stage => stage.replace('-complete', '')).join(', ')}]`;
                                 return (
-                                    `<div class="badge badge-outlined badge-${row.stage}">
+                                    `<div class="badge badge-outlined ${prLabelClasses[prLabelStage(row)]}">
                                         <span
                                             title="${hint}"
                                             data-toggle="tooltip"

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -47,6 +47,20 @@ export const PR_LABELS = {
   CLOSED: 'Closed',
 };
 
+export const PR_LABELS_CLASSNAMES = {
+  [PR_LABELS.WIP]: 'label-wip',
+  [PR_LABELS.WIP_DONE]: 'label-review-requested',
+  [PR_LABELS.REVIEW_PENDING]: 'label-review-pending',
+  [PR_LABELS.REVIEW_SUBMITTED]: 'label-review-submitted',
+  [PR_LABELS.REVIEW_REJECTED]: 'label-review-rejected',
+  [PR_LABELS.REVIEW_APPROVAL]: 'label-review-approval',
+  [PR_LABELS.MERGE_PENDING]: 'label-merge-pending',
+  [PR_LABELS.MERGE_COMPLETED]: 'label-merged',
+  [PR_LABELS.RELEASE_PENDING]: 'label-release-pending',
+  [PR_LABELS.RELEASE_COMPLETED]: 'label-released',
+  [PR_LABELS.CLOSED]: 'label-closed',
+};
+
 const realEvents = Object.keys(PR_EVENT).map(eventKey => PR_EVENT[eventKey]);
 
 export default pr => {

--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -65,27 +65,30 @@
             color: $danger;
         }
 
-        &.badge-wip {
+        &.label-wip,
+        &.label-review-requested {
             border-color: $color-wip;
             color: $color-wip;
         }
-
-        &.badge-review {
+        &.label-review-pending,
+        &.label-review-submitted,
+        &.label-review-rejected,
+        &.label-review-approval {
             border-color: $color-review;
             color: $color-review;
         }
-
-        &.badge-merge {
+        &.label-merge-pending,
+        &.label-merged {
             border-color: $color-merge;
             color: $color-merge;
         }
-
-        &.badge-release {
+        &.label-release-pending,
+        &.label-released {
             border-color: $color-release;
             color: $color-release;
         }
 
-        &.badge-done {
+        &.label-closed {
             border-color: $color-done;
             color: $color-done;
         }


### PR DESCRIPTION
required by [[ENG-456]]

_This PR does not introduce any visual change_

This PR prepares the PR labels to use their own colors. To do so, it will be only needed [to define css colors](https://github.com/athenianco/athenian-webapp/blob/master/src/sass/_variables.scss#L31) and to assign them [to the new label classes](https://github.com/athenianco/athenian-webapp/pull/178/files#diff-4f09eb729340b6778e426ca7f56d64fdR68).

[ENG-456]: https://athenianco.atlassian.net/browse/ENG-456