### PR TITLE
Implement 'One date with time' tooltip

### DIFF
--- a/src/js/components/charts/FilledAreaChart.jsx
+++ b/src/js/components/charts/FilledAreaChart.jsx
@@ -11,7 +11,7 @@ import { palette } from 'js/res/palette';
 import { dateTime } from 'js/services/format';
 import { hexToRGBA } from 'js/services/colors';
 
-import Tooltip, { onValueChange, onValueReset } from 'js/components/charts/Tooltip';
+import { DateBigNumber, BigText, onValueChange, onValueReset } from 'js/components/charts/Tooltip';
 
 export default ({ data, average, color = palette.schemes.primary, height = 300 }) => {
   const fillColor = hexToRGBA(color, .2);
@@ -44,7 +44,7 @@ export default ({ data, average, color = palette.schemes.primary, height = 300 }
           animation="stiff"
         />
 
-        {currentHover && <Tooltip value={currentHover} />}
+        {currentHover && <DateBigNumber value={currentHover} renderBigFn={v => <BigText content={dateTime.human(v.y)} />} />}
 
       </FlexibleWidthXYPlot>
     </div>

--- a/src/js/components/charts/Tooltip.jsx
+++ b/src/js/components/charts/Tooltip.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import _ from 'lodash';
 import classnames from 'classnames';
+import moment from 'moment';
 import { Hint } from 'react-vis';
+
+import { number } from 'js/services/format';
 
 export default ({value, ...props}) => {
     // TODO: This needs to be styled.
@@ -19,6 +22,21 @@ export default ({value, ...props}) => {
             }
 
           </div>
+        </Hint>
+    );
+};
+
+export const DateBigNumber = ({ value, renderBigFn = v => <BigText content={number.round(v.y)} />, ...props }) => {
+    if (!value) return null;
+
+    return (
+        <Hint {...props} value={value}>
+            <TooltipContainer left>
+                <Group>
+                    <SmallTitle content={<SmallDate date={moment(value.x)} />} />
+                    {renderBigFn(value)}
+                </Group>
+            </TooltipContainer>
         </Hint>
     );
 };

--- a/src/js/components/insights/charts/library/TimeSeries.jsx
+++ b/src/js/components/insights/charts/library/TimeSeries.jsx
@@ -15,7 +15,7 @@ import {
     MarkSeries
 } from 'react-vis';
 
-import Tooltip, { onValueChange, onValueReset } from 'js/components/charts/Tooltip';
+import { DateBigNumber, onValueChange, onValueReset } from 'js/components/charts/Tooltip';
 
 export default ({title, data, extra}) => (
     <div style={{ background: 'white' }}>
@@ -74,6 +74,7 @@ const TimeSeries = ({ title, data, extra }) => {
 
     const formattedData = _(data)
           .map(v => ({
+              ...v.legend && { legend: v.legend },
               x: v[extra.axisKeys.x],
               y: v[extra.axisKeys.y]
           }))
@@ -127,7 +128,7 @@ const TimeSeries = ({ title, data, extra }) => {
              animation="stiff"
            />}
 
-          {currentHover && <Tooltip value={currentHover} />}
+          <DateBigNumber value={currentHover} renderBigFn={extra?.tooltip?.renderBigFn} />
         </FlexibleWidthXYPlot>
     );
 };

--- a/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
+++ b/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
@@ -1,11 +1,14 @@
+import React from 'react';
+import moment from 'moment';
+import _ from 'lodash';
+
 import { SimpleKPI } from 'js/components/insights/KPI';
 import TimeSeries from 'js/components/insights/charts/library/TimeSeries';
+import { BigText } from 'js/components/charts/Tooltip';
 import { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 
 import { fetchPRsMetrics } from 'js/services/api/index';
-
-import moment from 'moment';
-import _ from 'lodash';
+import { number, dateTime } from 'js/services/format';
 
 const waitTimeFirstReview = {
     fetcher: async (api, context) => {
@@ -102,7 +105,10 @@ const waitTimeFirstReview = {
                                 axisLabels: {
                                     y: 'Wait Time, hours'
                                 },
-                                color: '#41CED3'
+                                color: '#41CED3',
+                                tooltip: {
+                                    renderBigFn: v => <BigText content={dateTime.human(v.y * 60 * 60 * 1000)} />,
+                                },
                             }
                         }
                     },

--- a/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
+++ b/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
@@ -1,10 +1,13 @@
-import { SimpleKPI } from 'js/components/insights/KPI';
-import TimeSeries from 'js/components/insights/charts/library/TimeSeries';
-
-import { fetchPRsMetrics } from 'js/services/api/index';
-
+import React from 'react';
 import moment from 'moment';
 import _ from 'lodash';
+
+import { SimpleKPI } from 'js/components/insights/KPI';
+import TimeSeries from 'js/components/insights/charts/library/TimeSeries';
+import { BigText } from 'js/components/charts/Tooltip';
+
+import { fetchPRsMetrics } from 'js/services/api/index';
+import { number } from 'js/services/format';
 
 const pullRequestRatioFlow = {
     fetcher: async (api, context) => fetchPRsMetrics(
@@ -16,7 +19,8 @@ const pullRequestRatioFlow = {
         chartData: _(fetched.calculated[0].values)
             .map(v => ({
                 day: v.date,
-                value: (v.values[1] || 1) / (v.values[2] || 1)
+                value: (v.values[1] || 1) / (v.values[2] || 1),
+                legend: [v.values[1], v.values[2]],
             }))
             .value(),
         KPIsData: {
@@ -66,8 +70,14 @@ const pullRequestRatioFlow = {
                             },
                             maxNumberOfTicks: 10,
                             axisKeys: computed.axisKeys,
-                            color: '#41CED3'
-                        }
+                            color: '#41CED3',
+                            tooltip: {
+                                renderBigFn: v => <BigText
+                                    content={`${v.legend[0] || 0}/${v.legend[1] || 0}`}
+                                    extra={number.round((v.legend[0] || 1) / (v.legend[1] || 1), 1)}
+                                />,
+                            },
+                        },
                     }
                 },
                 kpis: [


### PR DESCRIPTION
required by [[ENG-461]]

The new `One date with time` tooltip can act as:
- One date with time
- One date, time and pull requests
- PR Ratio Flow

To be used in:
- Summary metrics,
  
  ![image](https://user-images.githubusercontent.com/2437584/78418047-e0346e00-7638-11ea-82f0-3e8e3bdc62a9.png)

- Pull Request Ratio Flow,
  
  ![image](https://user-images.githubusercontent.com/2437584/78418054-f6422e80-7638-11ea-95f0-6bbd20ffeff2.png)

- Wait Time for 1st Review
  ![image](https://user-images.githubusercontent.com/2437584/78418350-a87af580-763b-11ea-97b0-74e257013078.png)




[ENG-461]: https://athenianco.atlassian.net/browse/ENG-461