### PR TITLE
Implement 'User Icon' tooltip

### DIFF
--- a/src/js/components/insights/charts/library/HorizontalBarChart.jsx
+++ b/src/js/components/insights/charts/library/HorizontalBarChart.jsx
@@ -60,21 +60,6 @@ const HorizontalBarChart = ({ title, data, extra }) => {
            }}/> : null
           }
 
-          {extra && extra.yAxis && extra.yAxis.imageMapping ?
-           <YAxis tickFormat={
-               (value) => (
-                   extra.yAxis.imageMapping[value] ?
-                       <image
-                         href={extra.yAxis.imageMapping[value]}
-                         clipPath={extra.yAxis.imageMask ? `url(#${extra.yAxis.imageMask}-mask)` : ""}
-                         width="30" height="30"
-                         transform="translate(-40,-15)"
-                       /> :
-                   value
-               )
-           } /> :
-           <YAxis />}
-
           {_(series).map((s, k) => <HorizontalBarSeries
                                      data={s.reverse()}
                                      color={extra.series[k].color}
@@ -83,6 +68,27 @@ const HorizontalBarChart = ({ title, data, extra }) => {
                                      onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
                                      onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
                                    />).value()}
+
+          { extra?.yAxis?.imageMapping && <UserNameBackground /> }
+
+          {extra && extra.yAxis && extra.yAxis.imageMapping ?
+           <YAxis tickFormat={
+               (value) => (
+                   extra.yAxis.imageMapping[value] ?
+		       <g className="userIcon">
+                           <image
+                             href={extra.yAxis.imageMapping[value]}
+                             clipPath={extra.yAxis.imageMask ? `url(#${extra.yAxis.imageMask}-mask)` : ""}
+                             width="30" height="30"
+                             transform="translate(-40,-15)"
+                           />
+                           <UserHint name={value} />
+                       </g> :
+                       value
+               )
+           } /> :
+           <YAxis />}
+
           {currentHover && <Tooltip value={currentHover} />}
         </FlexibleWidthXYPlot>
     );
@@ -98,3 +104,31 @@ const CircleMask = ({id, maskProperties}) => (
 );
 
 CircleMask.requiresSVG = true;
+
+const UserNameBackground = () => (
+    <defs>
+        <filter x="0" y="0" width="1" height="1" id="solid">
+            <feFlood floodColor="white" />
+            <feComposite in="SourceGraphic" />
+        </filter>
+    </defs>
+);
+
+UserNameBackground.requiresSVG = true;
+
+const userFontSize = 16;
+const UserHint = ({ name }) => (
+    // TODO(dpordomingo): Style the 'User Icon' tooltip using SVG native elements;
+    // alternative: investigate if it can be attached a javascript handler to <svg:image:onHover>,
+    //    and use it to handle the react-vis Hint passing the (x,y) position of the triggered event.
+    <text
+        className="userName"
+        x="0" y={30 + userFontSize * 1.3}
+        transform="translate(-40,-15)"
+        filter="url(#solid)"
+        fill="black"
+        fontSize={userFontSize}
+    >
+        {name}
+    </text>
+);

--- a/src/sass/components/_charts.scss
+++ b/src/sass/components/_charts.scss
@@ -1,0 +1,9 @@
+.userIcon{
+    .userName {
+        display: none;
+    }
+
+    &:hover .userName {
+        display: block;
+    }
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -13,6 +13,7 @@
 
 @import 'components/badges';
 @import 'components/buttons';
+@import 'components/charts';
 @import 'components/datepicker';
 @import 'components/dropdowns';
 @import 'components/filters';


### PR DESCRIPTION
`react-vis` does not support the native `<Hint>` for axis, so it was implemented, as a workaround, a text label next to the user image.
- If it is approved, it should be styled using SVG native elements to match our design for `User Icon` tooltip
- Alternative: investigate if it can be attached a javascript handler to `<svg:image:onHover>`, and use it to handle the `react-vis` `<Hint>` passing the `(x,y)` position of the triggered event.

To be used in `YAxis` of the following charts:
- Most Active Developer
- Review Activity :: ReviewComments/Reviews per reviewer

![image](https://user-images.githubusercontent.com/2437584/78523241-5d461b80-77d0-11ea-8a8a-9446080b8d6e.png)

