### PR TITLE
Smart granularity

### DIFF
--- a/src/js/components/charts/FilledAreaChart.jsx
+++ b/src/js/components/charts/FilledAreaChart.jsx
@@ -13,21 +13,25 @@ import { hexToRGBA } from 'js/services/colors';
 
 import { DateBigNumber, BigText, onValueChange, onValueReset } from 'js/components/charts/Tooltip';
 
+import { computeTickValues } from 'js/components/insights/charts/library/TimeSeries';
+
 export default ({ data, average, color = palette.schemes.primary, height = 300 }) => {
   const fillColor = hexToRGBA(color, .2);
   const [currentHover, setCurrentHover] = useState(null);
+  const tickValues = computeTickValues(data, 6);
   return (
     <div style={{ background: 'white' }}>
       <FlexibleWidthXYPlot
         height={height}
         margin={{ left: 100 }}
       >
-        <XAxis tickTotal={6}
+        <XAxis
+          tickValues={tickValues}
           tickFormat={dateTime.monthDay}
         />
         <YAxis tickTotal={3} tickFormat={dateTime.human} />
         <HorizontalGridLines tickTotal={3} />
-        <VerticalGridLines tickTotal={6} />
+        <VerticalGridLines tickValues={tickValues} />
         <AreaSeries data={data} stroke="none" fill={fillColor} animation="stiff" />
         <LineMarkSeries
           data={data}

--- a/src/js/components/insights/charts/library/TimeSeries.jsx
+++ b/src/js/components/insights/charts/library/TimeSeries.jsx
@@ -50,7 +50,7 @@ const buildChartLabel = (text, which) => {
     return <ChartLabel text={text} {...labelParams} />;
 };
 
-const computeTickValues = (formattedData, maxNumberOfTicks) => {
+export const computeTickValues = (formattedData, maxNumberOfTicks) => {
     const tickValues = _(formattedData)
           .map(v => v.x.getTime())
           .value();

--- a/src/js/components/pipeline/SummaryChart.jsx
+++ b/src/js/components/pipeline/SummaryChart.jsx
@@ -13,15 +13,15 @@ import _ from "lodash";
 
 export default ({name, metric, config}) => {
     const { api, ready: apiReady, context: apiContext } = useApi();
-    const { account, interval, repositories, contributors: developers } = apiContext;
-    const granularity = calculateGranularity(interval);
 
     if (!apiReady) {
         return null;
     }
 
+    const { account, interval, repositories, contributors: developers } = apiContext;
+    const granularity = calculateGranularity(interval);
     const adjustedInterval = {
-        from: moment(interval.from).subtract(1, 'days').toDate(),
+        from: moment(interval.from).subtract(1, granularity).toDate(),
         to: interval.to
     };
 
@@ -56,9 +56,16 @@ export default ({name, metric, config}) => {
 };
 
 const calculateGranularity = (interval) => {
-    // TODO: apply the following logic:
-    // <= 1 week: daily
-    // <= 2 months: weekly
-    // > 2 months: monthly
-    return 'day';
+    console.log(interval);
+    const diff = moment(interval.to).diff(interval.from, 'days');
+
+    if (diff <= 21) {
+        return 'day';
+    }
+
+    if (diff <= 90) {
+        return 'week';
+    }
+
+    return 'month';
 };

--- a/src/js/components/pipeline/SummaryChart.jsx
+++ b/src/js/components/pipeline/SummaryChart.jsx
@@ -6,6 +6,7 @@ import { useApi } from 'js/hooks';
 
 import FilledAreaChart from 'js/components/charts/FilledAreaChart';
 import Chart from 'js/components/charts/Chart';
+import { palette } from 'js/res/palette';
 
 import moment from 'moment';
 import _ from "lodash";
@@ -38,11 +39,18 @@ export default ({name, metric, config}) => {
           }))
           .value();
 
+    const defaultConfig = {
+        height: 280,
+        color: palette.stages[name],
+    };
+
+    const chartConfig = {...defaultConfig, ...config};
+
     return (
         <Chart
           id={`summary-chart-${name}`}
           component={FilledAreaChart} fetcher={fetcher} plumber={plumber}
-          config={config}
+          config={chartConfig}
         />
     );
 };

--- a/src/js/pages/pipeline/Overview.jsx
+++ b/src/js/pages/pipeline/Overview.jsx
@@ -10,7 +10,6 @@ import { SmallTitle } from 'js/components/ui/Typography';
 import SummaryChart from 'js/components/pipeline/SummaryChart';
 import Tabs from 'js/components/layout/Tabs';
 
-import { palette } from 'js/res/palette';
 import { dateTime, number } from 'js/services/format';
 
 export default () => {
@@ -30,8 +29,6 @@ export default () => {
                     name={leadtimeContext.stageName}
                     metric={leadtimeContext.metric}
                     config={{
-                        height: 280,
-                        color: palette.stages[leadtimeContext.stageName],
                         average: leadtimeContext.avg
                     }}
                   />;

--- a/src/js/pages/pipeline/Stage.jsx
+++ b/src/js/pages/pipeline/Stage.jsx
@@ -6,7 +6,6 @@ import Insights from 'js/components/insights/Insights';
 import Tabs from 'js/components/layout/Tabs';
 import PullRequests from 'js/components/pipeline/PullRequests';
 import SummaryChart from 'js/components/pipeline/SummaryChart';
-import { palette } from 'js/res/palette';
 
 import { pipelineStagesConf, getStage } from 'js/pages/pipeline/Pipeline';
 
@@ -43,8 +42,6 @@ export default () => {
                     name={activeStage.stageName}
                     metric={activeStage.metric}
                     config={{
-                        height: 280,
-                        color: palette.stages[activeStage.stageName],
                         average: activeStage.avg
                     }}
                   />;


### PR DESCRIPTION
Adds a smart granularity calculation for summary charts based on the following logic:

- <= 21 days => 'day'
- <= 90 days => 'week'
- else => 'month'

This PR also fixes the grid line by making it match with the x-axis labels.

## Screenshot

<img width="789" alt="Screenshot 2020-04-06 at 12 44 11" src="https://user-images.githubusercontent.com/5599208/78550428-5c2ee180-7804-11ea-845a-16d976431f59.png">
