### PR TITLE
CI tests in docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-language: node_js
-node_js:
-  - '13'
+language: minimal
 
 os:
   - linux
@@ -26,11 +24,13 @@ jobs:
     - stage: test
       name: 'Frontend Tests'
       script:
-        - make test
+        - docker build --target app-deps -t webapp-frontend-testing .
+        - docker run -e CI=true webapp-frontend-testing make test
     - stage: build
       name: 'Frontend Build'
       script:
-        - make build
+        - docker build --target app-builder -t webapp-frontend-building .
+        - docker run webapp-frontend-building make build
     - stage: deploy
       name: 'Deploy App'
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Build web app
-# ----------------
-FROM node:13.7-alpine AS app-builder
+# Install web app deps
+# --------------------
+FROM node:13.7-alpine AS app-deps
 
 WORKDIR /app
 
@@ -13,11 +13,20 @@ RUN apk update && \
     make dependencies
 
 COPY / .
-RUN make build
 
+# Build web app
+# --------------------
+FROM node:13.7-alpine AS app-builder
+
+WORKDIR /app
+COPY --from=app-deps /app /app
+
+RUN apk update && \
+    apk add make bash && \
+    make build
 
 # Build server
-# ----------------
+# --------------------
 FROM nginx:1.17-alpine
 
 COPY --from=app-builder /app/build /usr/share/nginx/html


### PR DESCRIPTION
This PR makes tests and build run inside docker container itself:
- makes both and tests more reliable as they run exactly in the same environment
- makes CI more stable, for example, today Travis was failing continuously in downloading node 13 using nvm, this is not more required since everything is done inside containers.