### PR TITLE
Tooltip user icon

### DIFF
--- a/src/js/components/charts/FilledAreaChart.jsx
+++ b/src/js/components/charts/FilledAreaChart.jsx
@@ -51,8 +51,7 @@ export default ({ data, average, color = palette.schemes.primary, height = 300 }
           animation="stiff"
         />
 
-        {currentHover && <DateBigNumber value={currentHover}
-                                        renderBigFn={v => <BigText content={dateTime.human(v.y * 1000)} />} />}
+        <DateBigNumber value={currentHover} renderBigFn={v => <BigText content={dateTime.human(v.y * 1000)} />} />
 
       </FlexibleWidthXYPlot>
     </div>

--- a/src/js/components/charts/Tooltip.jsx
+++ b/src/js/components/charts/Tooltip.jsx
@@ -7,6 +7,8 @@ import { Hint } from 'react-vis';
 import { number } from 'js/services/format';
 
 export default ({value, ...props}) => {
+    if (!value) return null;
+
     // TODO: This needs to be styled.
     // `value` is a flat key-value object
     return (

--- a/src/js/components/charts/Tooltip.jsx
+++ b/src/js/components/charts/Tooltip.jsx
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import classnames from 'classnames';
 import moment from 'moment';
 import { Hint } from 'react-vis';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faClock } from '@fortawesome/free-regular-svg-icons'
 
 import { number } from 'js/services/format';
 
@@ -37,6 +39,31 @@ export const DateBigNumber = ({ value, renderBigFn = v => <BigText content={numb
                 <Group>
                     <SmallTitle content={<SmallDate date={moment(value.x)} />} />
                     {renderBigFn(value)}
+                </Group>
+            </TooltipContainer>
+        </Hint>
+    );
+};
+
+export const PullRequestReview = ({ value, ...props }) => {
+    if (!value) return null;
+
+    const tooltip = value.tooltip;
+    return (
+        <Hint {...props} value={value}>
+            <TooltipContainer left>
+                <Group>
+                    <SmallTitle uppercase content={`#${tooltip.number}`} />
+                    <PullRequestRepoTitle repo={tooltip.repository} title={tooltip.title} />
+                </Group>
+                {tooltip.timeWaiting && (
+                    <Group className={tooltip.reviewed ? 'text-turquoise' : 'text-orange'}>
+                        <Icon icon={faClock} />
+                        <span>{tooltip.reviewed ? 'Waited' : 'Waiting'} review for {tooltip.timeWaiting}</span>
+                    </Group>
+                )}
+                <Group>
+                    <UserAvatar src={tooltip.image} name={tooltip.author} middleText="Created by" size="18" />
                 </Group>
             </TooltipContainer>
         </Hint>
@@ -105,5 +132,27 @@ export const BigText = ({ content, extra }) => (
 export const SmallDate = ({ date }) => (
     <>
         <span className="text-uppercase">{date.format('ddd')}</span>, {date.format('Do')} <span className="text-uppercase">{date.format('MMM')}</span>
+    </>
+);
+
+
+export const PullRequestRepoTitle = ({ repo, title }) => (
+    <span className="text-s">
+        <span className="text-secondary">{repo}: </span>
+        <span className="text-dark font-weight-bold">{title}</span>
+    </span>
+);
+
+export const Icon = ({ icon, className }) => (
+    <FontAwesomeIcon icon={icon} className={classnames('mr-1', className)} />
+);
+
+export const UserAvatar = ({ name, src, middleText, size = 30 }) => (
+    <>
+        <img src={src} alt={name} className="user-avatar inline-block" height={size} width={size} />
+        <span className="ml-2 inline-block font-weight-light align-middle">
+            {middleText && <span className="text-secondary">{middleText} </span>}
+            <span className={classnames('text-dark', !middleText ? 'text-m' : '')}>{name}</span>
+        </span>
     </>
 );

--- a/src/js/components/insights/charts/library/BubbleChart.jsx
+++ b/src/js/components/insights/charts/library/BubbleChart.jsx
@@ -33,6 +33,7 @@ const formatData = (data, extra) => _(data)
               y: extra.axisKeys && extra.axisKeys.y ? v[extra.axisKeys.y] : v.y,
               size: extra.axisKeys && extra.axisKeys.size ? v[extra.axisKeys.size] : v.size,
               label: extra.axisKeys && extra.axisKeys.label ? v[extra.axisKeys.label] : v.label,
+              tooltip: v.tooltip,
           };
 
           if (extra.grouper) {
@@ -58,7 +59,8 @@ const buildSeries = (title, formattedData, extra, currentHover, setCurrentHover)
                     x: transformer(v.x),
                     y: transformer(v.y),
                     size: v.size,
-                    label: v.label
+                    ...v.label && { label: v.label },
+                    ...v.tooltip && { tooltip: v.tooltip },
                 }))}
                 onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
                 onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
@@ -75,7 +77,8 @@ const buildSeries = (title, formattedData, extra, currentHover, setCurrentHover)
                           x: transformer(v.x),
                           y: transformer(v.y),
                           size: v.size,
-                          label: v.label,
+                          ...v.label && { label: v.label },
+                          ...v.tooltip && { tooltip: v.tooltip },
                           customComponent: () => (
                               <Pic
                                 url={
@@ -109,7 +112,8 @@ const buildSeries = (title, formattedData, extra, currentHover, setCurrentHover)
                       x: transformer(v.x),
                       y: transformer(v.y),
                       size: v.size,
-                      label: v.label
+                      ...v.label && { label: v.label },
+                      ...v.tooltip && { tooltip: v.tooltip },
                   }))}
                   onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
                   onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
@@ -136,6 +140,8 @@ const BubbleChart = ({ title, data, extra }) => {
           .map(v => ({ title: v.title, color: v.color }))
           .value();
 
+    const ChartTooltip = extra?.tooltip?.template || Tooltip;
+
     return (
         <FlexibleWidthXYPlot height={300} margin={{ top: 20, left: 50, right: 30, bottom: 50 }}>
 
@@ -155,7 +161,7 @@ const BubbleChart = ({ title, data, extra }) => {
           <YBubbleChartAxis formattedData={formattedData} label={extra.axisLabels.y} />
 
           {marksSeries}
-          <Tooltip value={currentHover} />
+          <ChartTooltip value={currentHover} />
 
         </FlexibleWidthXYPlot>
     );
@@ -202,6 +208,8 @@ const BubbleChartLogScale = ({ title, data, extra }) => {
     const maxValueY = _.maxBy(formattedData, 'y')['y'];
     const maxExpY = Math.floor(logScale(maxValueY) + 1);
 
+    const ChartTooltip = extra?.tooltip?.template || Tooltip;
+
     return (
         <FlexibleWidthXYPlot height={300} margin={{ left: 50, right: 30, bottom: 50 }}
                              xDomain={[0, maxExpX]} yDomain={[0, maxExpY]} >
@@ -215,7 +223,7 @@ const BubbleChartLogScale = ({ title, data, extra }) => {
           <YBubbleChartLogAxis formattedData={formattedData} label={extra.axisLabels.y} />
 
           {marksSeries}
-          <Tooltip value={currentHover} />
+          <ChartTooltip value={currentHover} />
 
         </FlexibleWidthXYPlot>
     );

--- a/src/js/components/insights/charts/library/BubbleChart.jsx
+++ b/src/js/components/insights/charts/library/BubbleChart.jsx
@@ -155,7 +155,7 @@ const BubbleChart = ({ title, data, extra }) => {
           <YBubbleChartAxis formattedData={formattedData} label={extra.axisLabels.y} />
 
           {marksSeries}
-          {currentHover && <Tooltip value={currentHover} />}
+          <Tooltip value={currentHover} />
 
         </FlexibleWidthXYPlot>
     );
@@ -215,7 +215,7 @@ const BubbleChartLogScale = ({ title, data, extra }) => {
           <YBubbleChartLogAxis formattedData={formattedData} label={extra.axisLabels.y} />
 
           {marksSeries}
-          {currentHover && <Tooltip value={currentHover} />}
+          <Tooltip value={currentHover} />
 
         </FlexibleWidthXYPlot>
     );

--- a/src/js/components/insights/charts/library/VerticalBarChart.jsx
+++ b/src/js/components/insights/charts/library/VerticalBarChart.jsx
@@ -51,7 +51,7 @@ const VerticalBarChart = ({ title, data, extra }) => {
             onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
           />
 
-          {currentHover && <Tooltip value={currentHover} />}
+          <Tooltip value={currentHover} />
         </FlexibleWidthXYPlot>
     );
 };

--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -1,69 +1,95 @@
-import { SimpleKPI, MultiKPI } from 'js/components/insights/KPI';
-import BubbleChart from 'js/components/insights/charts/library/BubbleChart';
-import { PR_STAGE } from 'js/services/prHelpers';
-
 import moment from 'moment';
 import _ from 'lodash';
+
+import { SimpleKPI, MultiKPI } from 'js/components/insights/KPI';
+import BubbleChart from 'js/components/insights/charts/library/BubbleChart';
+import { PullRequestReview } from 'js/components/charts/Tooltip';
+
+import { github, dateTime } from 'js/services/format';
+import { PR_STAGE } from 'js/services/prHelpers';
 
 const pullRequestSize = {
     fetcher: async (api, context, data) => {
         // TODO: call the api to avoid receiving data from outside
         return Promise.resolve(data);
     },
-    calculator: (data) => ({
-        chartData: _(data.prs)
-            .map(pr => {
-                let endTime;
-                if (pr.closed instanceof Date && !isNaN(pr.closed)) {
-                    endTime = moment(pr.closed);
-                } else if (pr.merged instanceof Date && !isNaN(pr.merged)) {
-                    endTime = moment(pr.merged);
-                } else {
-                    endTime = moment();
-                }
+    calculator: (data) => {
+        const avatarMapping = _(data.users)
+            .reduce((res, v, k) => {
+                res[_.replace(k, 'github.com/', '')] = v.avatar;
+                return res;
+            });
 
-                // TODO(dpordomingo): This Chart shows PRs in two groups: waiting for review or not.
-                //   Grouping criteria should be having review_happened or approve_happened or changes_request_happened or merge_happened or being closed.
-                //   But API since the tooltip also needs to show the time waiting for being reviewed, and the events
-                //   above do not expose it, we can only differentiate between being review-complete, or not.
-                const reviewed = pr.completedStages.includes(PR_STAGE.COMPLETE.REVIEW);
+        return {
+            chartData: _(data.prs)
+                .map(pr => {
+                    let endTime;
+                    if (pr.closed instanceof Date && !isNaN(pr.closed)) {
+                        endTime = moment(pr.closed);
+                    } else if (pr.merged instanceof Date && !isNaN(pr.merged)) {
+                        endTime = moment(pr.merged);
+                    } else {
+                        endTime = moment();
+                    }
 
-                return {
-                    loc: pr.size_added + pr.size_removed,
-                    files: pr.files_changed,
-                    label: pr.repository + " - #" + pr.number,
-                    age: endTime.diff(pr.created, 'hours'),
-                    reviewed,
-                };
-            })
-            .orderBy(['age', 'loc'], ['desc', 'desc'])
-            .take(20)
-            .value(),
-        totalFiles: _(data.prs)
-            .filter(pr => !pr.completedStages.includes(PR_STAGE.COMPLETE.REVIEW))
-            .map(pr => pr.files_changed)
-            .sum(),
-        totalLoc: _(data.prs)
-            .map(pr => pr.size_added + pr.size_removed)
-            .sum(),
-        totalPRs: data.prs.length,
-        axisKeys: {
-            x: 'loc',
-            y: 'files',
-            size: 'age'
-        },
-        grouper: 'reviewed',
-        groups: {
-            false: {
-                title: 'Waiting review',
-                color: '#FFC507'
+                    // TODO(dpordomingo): This Chart shows PRs in two groups: waiting for review or not.
+                    //   Grouping criteria should be having review_happened or approve_happened or changes_request_happened or merge_happened or being closed.
+                    //   But API since the tooltip also needs to show the time waiting for being reviewed, and the events
+                    //   above do not expose it, we can only differentiate between being review-complete, or not.
+                    const reviewed = pr.completedStages.includes(PR_STAGE.COMPLETE.REVIEW);
+
+                    const author = github.userName(pr.authors[0]);
+                    const timeWaiting = dateTime.interval(
+                        pr.review_requested || pr.created,
+                        pr.approved || endTime
+                    );
+                    const tooltip = {
+                        number: pr.number,
+                        repository: github.repoOrg(pr.repository),
+                        title: pr.title,
+                        image: avatarMapping[author],
+                        reviewed,
+                        author,
+                        timeWaiting,
+                    };
+
+                    return {
+                        loc: pr.size_added + pr.size_removed,
+                        files: pr.files_changed,
+                        age: endTime.diff(pr.created, 'hours'),
+                        reviewed,
+                        tooltip,
+                    };
+                })
+                .orderBy(['age', 'loc'], ['desc', 'desc'])
+                .take(20)
+                .value(),
+            totalFiles: _(data.prs)
+                .filter(pr => !pr.completedStages.includes(PR_STAGE.COMPLETE.REVIEW))
+                .map(pr => pr.files_changed)
+                .sum(),
+            totalLoc: _(data.prs)
+                .map(pr => pr.size_added + pr.size_removed)
+                .sum(),
+            totalPRs: data.prs.length,
+            axisKeys: {
+                x: 'loc',
+                y: 'files',
+                size: 'age'
             },
-            true: {
-                title: 'Review submitted',
-                color: '#23C2C7'
+            grouper: 'reviewed',
+            groups: {
+                false: {
+                    title: 'Waiting review',
+                    color: '#FFC507'
+                },
+                true: {
+                    title: 'Review submitted',
+                    color: '#23C2C7'
+                }
             }
-        }
-    }),
+        };
+    },
     factory: (computed) => ({
             meta: {
                 title: 'Pull Request Size',
@@ -84,7 +110,8 @@ const pullRequestSize = {
                                     x: 'Lines of code',
                                     y: 'Files'
                                 },
-                                isLogScale: true
+                                isLogScale: true,
+                                tooltip: { template: PullRequestReview },
                             }
                         }
                     },

--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -22,12 +22,18 @@ const pullRequestSize = {
                     endTime = moment();
                 }
 
+                // TODO(dpordomingo): This Chart shows PRs in two groups: waiting for review or not.
+                //   Grouping criteria should be having review_happened or approve_happened or changes_request_happened or merge_happened or being closed.
+                //   But API since the tooltip also needs to show the time waiting for being reviewed, and the events
+                //   above do not expose it, we can only differentiate between being review-complete, or not.
+                const reviewed = pr.completedStages.includes(PR_STAGE.COMPLETE.REVIEW);
+
                 return {
                     loc: pr.size_added + pr.size_removed,
                     files: pr.files_changed,
                     label: pr.repository + " - #" + pr.number,
                     age: endTime.diff(pr.created, 'hours'),
-                    reviewRequested: !!pr.review_requested,
+                    reviewed,
                 };
             })
             .orderBy(['age', 'loc'], ['desc', 'desc'])
@@ -46,7 +52,7 @@ const pullRequestSize = {
             y: 'files',
             size: 'age'
         },
-        grouper: 'reviewRequested',
+        grouper: 'reviewed',
         groups: {
             false: {
                 title: 'Waiting review',

--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -1,5 +1,6 @@
 import { SimpleKPI, MultiKPI } from 'js/components/insights/KPI';
 import BubbleChart from 'js/components/insights/charts/library/BubbleChart';
+import { PR_STAGE } from 'js/services/prHelpers';
 
 import moment from 'moment';
 import _ from 'lodash';
@@ -33,6 +34,7 @@ const pullRequestSize = {
             .take(20)
             .value(),
         totalFiles: _(data.prs)
+            .filter(pr => !pr.completedStages.includes(PR_STAGE.COMPLETE.REVIEW))
             .map(pr => pr.files_changed)
             .sum(),
         totalLoc: _(data.prs)

--- a/src/js/pages/prototypes/Tooltips.jsx
+++ b/src/js/pages/prototypes/Tooltips.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClock, faCommentAlt, faUser } from '@fortawesome/free-regular-svg-icons'
 import { faCodeBranch } from '@fortawesome/free-solid-svg-icons'
 
@@ -19,7 +17,10 @@ import {
   Group,
   BigText,
   SmallTitle,
-  SmallDate
+  SmallDate,
+  PullRequestRepoTitle,
+  Icon,
+  UserAvatar,
 } from 'js/components/charts/Tooltip';
 import moment from 'moment';
 
@@ -27,27 +28,6 @@ const SmallText = ({ content }) => (
   <span className="font-weight-bold d-inline-block align-middle text-dark text-m">
     {content}
   </span>
-);
-
-const UserAvatar = ({ name, src, middleText, size = 30 }) => (
-  <>
-    <img src={src} alt={name} className="user-avatar inline-block" height={size} width={size} />
-    <span className="ml-2 inline-block font-weight-light align-middle">
-      {middleText && <span className="text-secondary">{middleText} </span>}
-      <span className={classnames('text-dark', !middleText ? 'text-m' : '')}>{name}</span>
-    </span>
-  </>
-);
-
-const PullRequestRepoTitle = ({ repo, title }) => (
-  <span className="text-s">
-    <span className="text-secondary">{repo}: </span>
-    <span className="text-dark font-weight-bold">{title}</span>
-  </span>
-);
-
-const Icon = ({ icon, className }) => (
-  <FontAwesomeIcon icon={icon} className={classnames('mr-1', className)} />
 );
 
 const PRCommentsStats = ({ prs, comments }) => (

--- a/src/js/services/format.js
+++ b/src/js/services/format.js
@@ -36,7 +36,7 @@ const human = milliseconds => {
         return Math.round(milliseconds / DAY) + ' days';
     } else if (milliseconds <= 8 * WEEK) {
         return Math.round(milliseconds / WEEK) + ' weeks';
-    } else if (milliseconds <= 24 * MONTH) {
+    } else if (milliseconds <= 22 * MONTH) {
         return Math.round(milliseconds / MONTH) + ' months';
     } else if (milliseconds <= 5 * YEAR) {
         return Math.round(milliseconds / YEAR) + ' years';

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -129,6 +129,11 @@ const extractCompletedStages = pr => {
       PR_STAGE.COMPLETE.MERGE,
       PR_STAGE.COMPLETE.RELEASE
     ];
+  } else if (pr.stage === PR_STAGE.DONE) {
+    return [
+      PR_STAGE.COMPLETE.WIP,
+      PR_STAGE.COMPLETE.REVIEW
+    ];
   } else if (pr.stage === PR_STAGE.RELEASE) {
     return [
       PR_STAGE.COMPLETE.WIP,


### PR DESCRIPTION
required by [[ENG-461]]

Implement tooltips:
- `Regular Pull Request`
- `Pull Request waiting for Review`
- `Pull Request Reviewed`

To be used in:
- Pull Request Size, review chart

## Main change:

- c5bc0581b73b9926a38ae28b8db69d2365cdae3e Adds the tooltip

## Other changes

- d7e5856 Make `Total number of files waiting for review` KPI count files waiting for review, instead of counting all files (also already approved ones)
- 07d411e Fix grouping of Pull Request Size review chart
This Chart shows PRs in two groups: waiting for review or not.
Grouping criteria should be having `review_happened` or `approve_happened` or `changes_request_happened` or `merge_happened` or being `closed`.
But since the tooltip also needs to show the time waiting for being reviewed, and the events
above do not expose it, we can only differentiate between being `review-complete`, or not.
Also, having `review_requested` (as done with the old implementation) is not a valid grouping key because:
  - a PR can be approved (thus, having a review) without having `review_requested,
  - and a PR can be still waiting for review even having `review_requested`.

## Other minors
- d16467f Check Tooltip value in Tooltip component 
- ae0c3c2 Add `wip-complete` and `review-complete` into rejected (closed) PRs 
- 89da2ce Enhance `dateTime.human`; 24 monts is 2 years

![image](https://user-images.githubusercontent.com/2437584/78635578-d7e16a80-78a6-11ea-87fb-442b77840bf7.png)



[ENG-461]: https://athenianco.atlassian.net/browse/ENG-461