### PR TITLE
Fix repo name representation. Add org name

### DIFF
--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -45,7 +45,7 @@ const pullRequestSize = {
                     );
                     const tooltip = {
                         number: pr.number,
-                        repository: github.repoOrg(pr.repository),
+                        repository: pr.organization + '/' + pr.repo,
                         title: pr.title,
                         image: avatarMapping[author],
                         reviewed,

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -110,7 +110,7 @@ export default ({ stage, data }) => {
                             case 'display':
                                 return `
                                     <div class="table-title">
-                                        <span class="text-secondary">${github.repoOrg(row.repository)}/${github.repoName(row.repository)}:</span>
+                                        <span class="text-secondary">${row.organization}/${row.repo}:</span>
                                         <a class="text-dark font-weight-bold" href=${github.prLink(row.repository, row.number)} target="_blank">${row.title}</a>
                                     </div>
                                     <div class="table-creators">


### PR DESCRIPTION
`Pull Request Size` chart was missing the repo org name in its tooltip