### PR TITLE
Add pr.number in PRs tables

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -111,7 +111,10 @@ export default ({ stage, data }) => {
                                 return `
                                     <div class="table-title">
                                         <span class="text-secondary">${row.organization}/${row.repo}:</span>
-                                        <a class="text-dark font-weight-bold" href=${github.prLink(row.repository, row.number)} target="_blank">${row.title}</a>
+                                        <a class="text-dark font-weight-bold" href=${github.prLink(row.repository, row.number)} target="_blank">
+                                            <span class="text-secondary">#${row.number}</span>
+                                            ${row.title}
+                                        </a>
                                     </div>
                                     <div class="table-creators">
                                         ${row.authors.map(userImage(users)).join(' ')}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2437584/78866674-2118f200-7a40-11ea-9fb8-1f4f38febf58.png)

The alternative would be to add the `pr.number` after the title, but it will be not visible in many prs because their titles are cropped because they're too long. See example below:
![image](https://user-images.githubusercontent.com/2437584/78866848-735a1300-7a40-11ea-8ea6-3448a5225e56.png)
