### PR TITLE
Removes adjusted interval from summary chart and pipeline mini chart

### DIFF
--- a/src/js/components/pipeline/PipelineCardMiniChart.jsx
+++ b/src/js/components/pipeline/PipelineCardMiniChart.jsx
@@ -19,14 +19,10 @@ export default ({name, metric, config}) => {
 
     const { account, interval, repositories, contributors: developers } = apiContext;
     const granularity = calculateGranularity(interval);
-    const adjustedInterval = {
-        from: moment(interval.from).subtract(1, granularity).toDate(),
-        to: interval.to
-    };
 
     const fetcher = async () => {
         return fetchPRsMetrics(
-            api, account, granularity, adjustedInterval, [metric],
+            api, account, granularity, interval, [metric],
             { repositories, developers }
         );
     };

--- a/src/js/components/pipeline/SummaryChart.jsx
+++ b/src/js/components/pipeline/SummaryChart.jsx
@@ -20,14 +20,10 @@ export default ({name, metric, config}) => {
 
     const { account, interval, repositories, contributors: developers } = apiContext;
     const granularity = calculateGranularity(interval);
-    const adjustedInterval = {
-        from: moment(interval.from).subtract(1, granularity).toDate(),
-        to: interval.to
-    };
 
     const fetcher = async () => {
         return fetchPRsMetrics(
-            api, account, granularity, adjustedInterval, [metric],
+            api, account, granularity, interval, [metric],
             { repositories, developers }
         );
     };


### PR DESCRIPTION
Closes [ENG-549](https://athenianco.atlassian.net/browse/ENG-549)

Then only queries using adjusted interval were summary chart and mini charts.