### PR TITLE
Fix Created PRs from WIP summary metrics

### DIFF
--- a/src/js/pages/pipeline/Pipeline.jsx
+++ b/src/js/pages/pipeline/Pipeline.jsx
@@ -39,7 +39,7 @@ export const pipelineStagesConf = [
         prs: prs => prs.filter(pr => pr.properties.includes(prStage.WIP) || pr.completedStages.includes(prStageComplete.WIP)),
         stageCompleteCount: prs => prs.filter(pr => pr.completedStages.includes(prStageComplete.WIP)).length,
         summary: (stage, prs, dateInterval) => {
-            const createdPrs = prs.filter(pr => dateInterval.from < pr.created && pr.created < dateInterval.to);
+            const createdPrs = prs.filter(pr => dateInterval.from <= pr.created);
             const authors = distinct(createdPrs, pr => pr.authors);
             const repos = distinct(createdPrs, pr => pr.repository);
             return [


### PR DESCRIPTION
Filter must consider only those created after the filter.from, ignoring the filter.to,
which is already considered by the API

Signed-off-by: David Pordomingo <David.Pordomingo.F@gmail.com>