### PR TITLE
Improving the text tooltips

### DIFF
--- a/src/sass/components/_tooltips.scss
+++ b/src/sass/components/_tooltips.scss
@@ -33,3 +33,36 @@
 .user-info {
     font-size: 1.5rem;
 }
+
+// Info tooltips
+
+.tooltip.show {
+    opacity: 1 !important;
+}
+
+.tooltip-inner {
+    max-width: 250px !important;
+    padding: 1rem 1.5rem !important;
+    box-shadow: 0 0 7px rgba(0,0,0,0.2) !important;
+    color: $color-dark !important;
+    background-color: $white !important;
+    font-size: 1.2rem !important;
+    opacity: 1 !important;
+    text-align: left !important;
+}
+
+.bs-tooltip-auto[x-placement^=bottom] .arrow::before, .bs-tooltip-bottom .arrow::before {
+    border-bottom-color: $white !important;
+}
+
+.bs-tooltip-auto[x-placement^=top] .arrow::before, .bs-tooltip-top .arrow::before {
+    border-top-color: $white !important;
+}
+
+.bs-tooltip-auto[x-placement^=left] .arrow::before, .bs-tooltip-left .arrow::before {
+    border-left-color: $white !important;
+}
+
+.bs-tooltip-auto[x-placement^=right] .arrow::before, .bs-tooltip-right .arrow::before {
+    border-right-color: $white !important;
+}


### PR DESCRIPTION
This is related to the issues [#ENG-446](https://athenianco.atlassian.net/browse/ENG-446) and [#ENG-566](https://athenianco.atlassian.net/browse/ENG-566). 

It improves the styles of the text tooltips to make the background white to match the chart tooltips and to make the text larger for a better readability.

![image](https://user-images.githubusercontent.com/14981468/79116965-11741300-7d8a-11ea-8e23-924c82434a7a.png)
 
Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>