### PR TITLE
Fixing the info icon alignment

### DIFF
--- a/src/js/components/pipeline/MainMetrics.jsx
+++ b/src/js/components/pipeline/MainMetrics.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Badge, { NEGATIVE_IS_BETTER, POSITIVE_IS_BETTER } from 'js/components/ui/Badge';
-import { BigNumber } from 'js/components/ui/Typography';
+import { BigNumber, SmallTitle } from 'js/components/ui/Typography';
 import Info from 'js/components/ui/Info';
 
 import { dateTime, number } from 'js/services/format';
@@ -47,10 +47,10 @@ const MainMetric = ({ title, hint, value, variation, negativeIsBetter = false })
         <div className="card-body py-2 px-3">
             <div className="card-title mb-0">
                 <div className="d-flex justify-content-between align-items-center">
-                    <div className="font-weight-bold text-uppercase text-xs">
-                        <span className="align-middle">{title}</span>
-                        {hint && <Info content={hint} />}
-                    </div>
+                    <span className="align-middle">
+                        <SmallTitle content={title} />
+                        <Info content={hint} />
+                    </span>
                     <div className="d-flex align-items-center">
                         <BigNumber content={value} />
                         {value ? <Badge

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -45,10 +45,12 @@ const Stage = ({ title, text, hint, badge, variation, color, name, metric, activ
         <div className={classnames('card pipeline-thumbnail', active && 'active')} onClick={onClick}>
             <div className="card-body p-3">
                 <div className="card-title d-flex justify-content-between align-items-center mb-3">
-                    <span>
-                        <SmallTitle content={title} />
-                        <Info content={hint} />
-                    </span>
+                    <div className="d-flex justify-content-between align-items-center">
+                        <div className="font-weight-bold text-uppercase text-xs">
+                            <span className="align-middle">{title}</span>
+                            <Info content={hint} />
+                        </div>
+                    </div>
                     {badge && <Badge value={badge} />}
                 </div>
                 <div className="row no-gutters card-text">

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -45,12 +45,10 @@ const Stage = ({ title, text, hint, badge, variation, color, name, metric, activ
         <div className={classnames('card pipeline-thumbnail', active && 'active')} onClick={onClick}>
             <div className="card-body p-3">
                 <div className="card-title d-flex justify-content-between align-items-center mb-3">
-                    <div className="d-flex justify-content-between align-items-center">
-                        <div className="font-weight-bold text-uppercase text-xs">
-                            <span className="align-middle">{title}</span>
-                            <Info content={hint} />
-                        </div>
-                    </div>
+                    <span>
+                        <SmallTitle content={title} />
+                        <Info content={hint} />
+                    </span>
                     {badge && <Badge value={badge} />}
                 </div>
                 <div className="row no-gutters card-text">
@@ -65,6 +63,6 @@ const Stage = ({ title, text, hint, badge, variation, color, name, metric, activ
                     </div>
                 </div>
             </div>
-        </div >
+        </div>
     );
 };

--- a/src/js/components/ui/Info.jsx
+++ b/src/js/components/ui/Info.jsx
@@ -7,8 +7,8 @@ export default ({ content }) => {
     }, [])
 
     return (
-        <span data-toggle="tooltip" data-placement="bottom" title={content} className="ml-2">
-            <i className="icon-info align-middle"></i>
+        <span data-toggle="tooltip" data-placement="bottom" title={content} className="ml-2 info-tooltip align-middle">
+            <i className="icon-info"></i>
         </span>
     );
 };

--- a/src/js/components/ui/Typography.jsx
+++ b/src/js/components/ui/Typography.jsx
@@ -8,5 +8,5 @@ export const BigNumber = ({ content, isXL, className }) => (
 );
 
 export const SmallTitle = ({ content, isBlack, className }) => (
-    <span className={classnames('small-title font-weight-bold text-xs text-uppercase', isBlack && 'text-gray-900', className)}>{content || nbsp}</span>
+    <span className={classnames('small-title font-weight-bold text-xs text-uppercase align-middle', isBlack && 'text-gray-900', className)}>{content || nbsp}</span>
 );

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -93,3 +93,7 @@ html {
 .text-blue {
     color: $color-blue;
 }
+
+.small-title {
+    line-height: 2rem;
+}

--- a/src/sass/components/_tooltips.scss
+++ b/src/sass/components/_tooltips.scss
@@ -33,3 +33,10 @@
 .user-info {
     font-size: 1.5rem;
 }
+
+// Info Tooltip
+
+.info-tooltip {
+    font-size: 1.4rem;
+    line-height: 1.2rem;
+}


### PR DESCRIPTION
This is related to the issue [#ENG-567](https://athenianco.atlassian.net/browse/ENG-567).

It fixes the icon misalignment on the main metrics tabs.

![image](https://user-images.githubusercontent.com/14981468/79117985-e2ab6c00-7d8c-11ea-8704-79bb5d512ab5.png)
