### PR TITLE
Fixing sort icon on table columns and order by creation date

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -45,6 +45,7 @@ export default ({ stage, data }) => {
             `,
             searching: true,
             ordering: true,
+            order: [[ 1, 'desc' ]],
             language: {
                 paginate: {
                     next: "<i class='fas fa-angle-right'></i>",
@@ -64,11 +65,11 @@ export default ({ stage, data }) => {
             fixedHeader: true,
             data: prs,
             columnDefs: [
-                { "width": "50px", "targets": 0 },  //status
+                { "width": "50px", "targets": 0, "orderable": false },  //status
                 { "width": "130px", "targets": 2 }, //changes
-                { "width": "65px", "targets": 3 },  //comments
+                { "width": "90px", "targets": 3 },  //comments
                 { "width": "130px", "targets": 4 }, //participants
-                { "width": "70px", "targets": 5 },  //age
+                { "width": "100px", "targets": 5 },  //age
                 { "width": "150px", "targets": 6 }, //stage
             ],
             columns: [
@@ -105,7 +106,7 @@ export default ({ stage, data }) => {
                     },
                 },
                 {
-                    title: 'Pull Requests | Created',
+                    title: '<span class="table-head">Pull Requests | Created</span>',
                     className: 'pr-main',
                     render: (__, type, row) => {
                         switch (type) {
@@ -132,7 +133,7 @@ export default ({ stage, data }) => {
                         }
                     },
                 }, {
-                    title: 'Size',
+                    title: '<span class="table-head">Size</span>',
                     className: 'pr-size',
                     searchable: false,
                     render: (__, type, row) => {
@@ -153,7 +154,7 @@ export default ({ stage, data }) => {
                         }
                     },
                 }, {
-                    title: 'Comments',
+                    title: '<span class="table-head">Comments</span>',
                     className: 'pr-comments',
                     searchable: false,
                     render: (__, type, row) => {
@@ -169,7 +170,7 @@ export default ({ stage, data }) => {
                         }
                     },
                 }, {
-                    title: 'Reviewers',
+                    title: '<span class="table-head">Reviewers</span>',
                     className: 'pr-reviewers',
                     render: (__, type, row) => {
                         switch (type) {
@@ -185,7 +186,7 @@ export default ({ stage, data }) => {
                     },
                 },
                 cycleTimeColumn(stage, data), {
-                    title: 'Stage',
+                    title: '<span class="table-head">Stage</span>',
                     className: 'align-middle text-center',
                     render: (__, type, row) => {
                         switch (type) {
@@ -232,11 +233,11 @@ export default ({ stage, data }) => {
 
 const cycleTimeColumn = (stage, data) => {
     const title = {
-        overview: 'Lead Time',
-        wip: 'WIP Time',
-        review: 'Review Time',
-        merge: 'Merge Time',
-        release: 'Release Time'
+        overview: '<span class="table-head">Lead Time</span>',
+        wip: '<span class="table-head">WIP Time</span>',
+        review: '<span class="table-head">Review Time</span>',
+        merge: '<span class="table-head">Merge Time</span>',
+        release: '<span class="table-head">Release Time</span>'
     }[stage];
 
     return {

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -106,7 +106,7 @@ export default ({ stage, data }) => {
                     },
                 },
                 {
-                    title: '<span class="table-head">Pull Requests | Created</span>',
+                    title: 'Pull Requests | Created',
                     className: 'pr-main',
                     render: (__, type, row) => {
                         switch (type) {
@@ -133,7 +133,7 @@ export default ({ stage, data }) => {
                         }
                     },
                 }, {
-                    title: '<span class="table-head">Size</span>',
+                    title: 'Size',
                     className: 'pr-size',
                     searchable: false,
                     render: (__, type, row) => {
@@ -154,7 +154,7 @@ export default ({ stage, data }) => {
                         }
                     },
                 }, {
-                    title: '<span class="table-head">Comments</span>',
+                    title: 'Comments',
                     className: 'pr-comments',
                     searchable: false,
                     render: (__, type, row) => {
@@ -170,7 +170,7 @@ export default ({ stage, data }) => {
                         }
                     },
                 }, {
-                    title: '<span class="table-head">Reviewers</span>',
+                    title: 'Reviewers',
                     className: 'pr-reviewers',
                     render: (__, type, row) => {
                         switch (type) {
@@ -186,7 +186,7 @@ export default ({ stage, data }) => {
                     },
                 },
                 cycleTimeColumn(stage, data), {
-                    title: '<span class="table-head">Stage</span>',
+                    title: 'Stage',
                     className: 'align-middle text-center',
                     render: (__, type, row) => {
                         switch (type) {
@@ -233,11 +233,11 @@ export default ({ stage, data }) => {
 
 const cycleTimeColumn = (stage, data) => {
     const title = {
-        overview: '<span class="table-head">Lead Time</span>',
-        wip: '<span class="table-head">WIP Time</span>',
-        review: '<span class="table-head">Review Time</span>',
-        merge: '<span class="table-head">Merge Time</span>',
-        release: '<span class="table-head">Release Time</span>'
+        overview: 'Lead Time',
+        wip: 'WIP Time',
+        review: 'Review Time',
+        merge: 'Merge Time',
+        release: 'Release >'
     }[stage];
 
     return {

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -18,6 +18,13 @@
         border: 1px solid $at-border-color !important;
         color: $secondary;
 
+        &.table-no-tit {
+            display: block;
+            height: 10px;
+            width: 0;
+            margin: -16px 0;
+        }
+
         tr {
             height: 30px;
         }
@@ -29,6 +36,11 @@
             text-align: left !important;
             transform: translateY(2px);
             border: 0;
+
+            &.pr-merged {
+                padding-right: 0 !important;
+                width: 30px !important;
+            }
 
             &.sorting_asc,
             &.sorting_desc {
@@ -80,38 +92,33 @@
         &:first-child {
             border-left-width: 1px !important;
         }
-    }
 
-    td.pr-size,
-    td.pr-cycle-time {
-        white-space: nowrap;
-    }
+        &.pr-size,
+        &.pr-cycle-time {
+            white-space: nowrap;
+        }
 
-    td.pr-cycle-time {
-        font-size: 1.1rem;
-    }
+        &.pr-cycle-time {
+            font-size: 1.1rem;
+        }
 
-    td.pr-reviewers,
-    td.pr-size {
-        min-width: 140px;
-        width: 140px;
-    }
+        &.pr-reviewers,
+        &.pr-size {
+            min-width: 140px;
+            width: 140px;
+        }
 
-    td.pr-comments,
-    td.pr-cycle-time {
-        width: 80px;
-    }
+        &.pr-comments,
+        &.pr-cycle-time {
+            width: 80px;
+        }
 
-    td.pr-merged {
-        vertical-align: middle;
-        padding: 0 0 0 12px;
-        text-align: center;
-        width: 60px;
-    }
-
-    th.pr-merged {
-        padding-right: 0 !important;
-        width: 30px !important;
+        &.pr-merged {
+            vertical-align: middle;
+            padding: 0 0 0 12px;
+            text-align: center;
+            width: 60px;
+        }
     }
 
     $mainAvatarSize: 26px;
@@ -174,39 +181,28 @@
     }
 }
 
-div.dataTables_wrapper div.dataTables_length select {
-    margin-left: .6rem;
-    width: 5rem !important;
-}
-
-div.dataTables_wrapper div.dataTables_filter {
-    text-align: left !important;
-
-    .field-icon {
-        position: absolute;
-        opacity: 0.5;
-        left: 1.1rem;
-        top: 1rem;
+div.dataTables_wrapper div{
+    &.dataTables_length select {
+        margin-left: .6rem;
+        width: 5rem !important;
     }
 
-    .form-control {
-        width: 40rem;
-        padding-left: 3rem;
-        font-size: 1.2rem;
-        font-weight: 300;
-        margin-left: 0;
-    }
-}
+    &.dataTables_filter {
+        text-align: left !important;
 
-// Custom sort icons
+        .field-icon {
+            position: absolute;
+            opacity: 0.5;
+            left: 1.1rem;
+            top: 1rem;
+        }
 
-table.dataTable thead span.table-head {
-    position: relative;
-
-    &.table-no-tit {
-        display: block;
-        height: 10px;
-        width: 0px;
-        margin: -16px 0;
+        .form-control {
+            width: 40rem;
+            padding-left: 3rem;
+            font-size: 1.2rem;
+            font-weight: 300;
+            margin-left: 0;
+        }
     }
 }

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -18,6 +18,15 @@
         border: 1px solid $at-border-color !important;
         color: $secondary;
 
+        th {
+            padding: 0.8rem 0 1rem 1rem !important;
+
+            &.sorting_asc,
+            &.sorting_desc {
+                color: $color-dark !important;
+            }
+        }
+
         tr {
             height: 30px;
         }
@@ -38,8 +47,9 @@
         .sorting_asc:before,
         .sorting_desc:after {
             color: $dark;
-            left: 10px;
+            left: auto;
             opacity: 1;
+            right: 1rem;
         }
 
         th {
@@ -54,14 +64,13 @@
             &.sorting_asc:after,
             &.sorting_desc:after
             {
-                left: 10px;
-                right: auto;
+                left: auto;
+                right: 1rem;
             }
 
             &.sorting_asc,
             &.sorting_desc {
                 color: $dark;
-                padding-left: 24px !important;
             }
         }
     }
@@ -195,4 +204,69 @@ div.dataTables_wrapper div.dataTables_filter {
         font-weight: 300;
         margin-left: 0;
     }
+}
+
+// Custom sort icons
+
+table.dataTable thead span.table-head {
+    position: relative;
+
+    &.table-no-tit {
+        display: block;
+        height: 10px;
+        width: 0px;
+        margin: -16px 0;
+    }
+}
+
+table.dataTable thead .sorting:before,
+table.dataTable thead .sorting_asc:before,
+table.dataTable thead .sorting_desc:before,
+table.dataTable thead .sorting_asc_disabled:before,
+table.dataTable thead .sorting_desc_disabled:before,
+table.dataTable thead .sorting:after,
+table.dataTable thead .sorting_asc:after,
+table.dataTable thead .sorting_desc:after,
+table.dataTable thead .sorting_asc_disabled:after,
+table.dataTable thead .sorting_desc_disabled:after {
+    content: '' !important;
+    opacity: 0 !important;
+}
+
+table.dataTable thead .sorting span:after,
+table.dataTable thead .sorting_asc span:after,
+table.dataTable thead .sorting_desc span:after,
+table.dataTable thead .sorting_asc_disabled span:after,
+table.dataTable thead .sorting_desc_disabled span:after {
+    right: -1.5rem;
+    content: "\2193";
+    position: absolute;
+}
+
+table.dataTable thead .sorting span:before,
+table.dataTable thead .sorting_asc span:before,
+table.dataTable thead .sorting_desc span:before,
+table.dataTable thead .sorting_asc_disabled span:before,
+table.dataTable thead .sorting_desc_disabled span:before {
+    right: -1.5rem;
+    content: "\2191";
+    position: absolute;
+}
+
+#dataTable thead .sorting span:before,
+#dataTable thead .sorting span:after,
+#dataTable thead .sorting_asc span:before,
+#dataTable thead .sorting_asc span:after,
+#dataTable thead .sorting_desc span:before,
+#dataTable thead .sorting_desc span:after,
+#dataTable thead .sorting_asc_disabled span:before,
+#dataTable thead .sorting_asc_disabled span:after,
+#dataTable thead .sorting_desc_disabled span:before,
+#dataTable thead .sorting_desc_disabled span:after {
+    opacity: 0;
+}
+
+#dataTable thead .sorting_asc span:before,
+#dataTable thead .sorting_desc span:after {
+    opacity: 1;
 }

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -18,59 +18,51 @@
         border: 1px solid $at-border-color !important;
         color: $secondary;
 
-        th {
-            padding: 0.8rem 0 1rem 1rem !important;
-
-            &.sorting_asc,
-            &.sorting_desc {
-                color: $color-dark !important;
-            }
-        }
-
         tr {
             height: 30px;
-        }
-
-        .sorting:before,
-        .sorting:after,
-        .sorting_asc:before,
-        .sorting_asc:after,
-        .sorting_desc:before,
-        .sorting_desc:after,
-        .sorting_asc_disabled:before,
-        .sorting_asc_disabled:after,
-        .sorting_desc_disabled:before,
-        .sorting_desc_disabled:after {
-            opacity: 0;
-        }
-
-        .sorting_asc:before,
-        .sorting_desc:after {
-            color: $dark;
-            left: auto;
-            opacity: 1;
-            right: 1rem;
         }
 
         th {
             @extend .text-xs;
             @extend .text-uppercase;
-            padding: 8px 0 10px 10px;
+            padding: 0.8rem 0 1rem 1rem !important;
             text-align: left !important;
             transform: translateY(2px);
             border: 0;
 
-            &.sorting:after,
-            &.sorting_asc:after,
-            &.sorting_desc:after
-            {
-                left: auto;
-                right: 1rem;
-            }
-
             &.sorting_asc,
             &.sorting_desc {
-                color: $dark;
+                color: $color-dark !important;
+            }
+
+            &.sorting {
+                &:after,
+                &:before {
+                    opacity: 0 !important;
+                }
+            }
+
+            &.sorting_desc,
+            &.sorting_asc {
+                &:before {
+                    content: none !important;
+                }
+
+                &:after {
+                    opacity: 1 !important;
+                    position: static;
+                    display: inline;
+                    margin-left: 1rem;
+                    color: $dark !important;
+                }
+            }
+
+            &.sorting_desc:after {
+                content: '\2193' !important;
+            }
+
+            &.sorting_asc:after {
+                content: '\2191' !important;
             }
         }
     }
@@ -217,56 +209,4 @@ table.dataTable thead span.table-head {
         width: 0px;
         margin: -16px 0;
     }
-}
-
-table.dataTable thead .sorting:before,
-table.dataTable thead .sorting_asc:before,
-table.dataTable thead .sorting_desc:before,
-table.dataTable thead .sorting_asc_disabled:before,
-table.dataTable thead .sorting_desc_disabled:before,
-table.dataTable thead .sorting:after,
-table.dataTable thead .sorting_asc:after,
-table.dataTable thead .sorting_desc:after,
-table.dataTable thead .sorting_asc_disabled:after,
-table.dataTable thead .sorting_desc_disabled:after {
-    content: '' !important;
-    opacity: 0 !important;
-}
-
-table.dataTable thead .sorting span:after,
-table.dataTable thead .sorting_asc span:after,
-table.dataTable thead .sorting_desc span:after,
-table.dataTable thead .sorting_asc_disabled span:after,
-table.dataTable thead .sorting_desc_disabled span:after {
-    right: -1.5rem;
-    content: "\2193";
-    position: absolute;
-}
-
-table.dataTable thead .sorting span:before,
-table.dataTable thead .sorting_asc span:before,
-table.dataTable thead .sorting_desc span:before,
-table.dataTable thead .sorting_asc_disabled span:before,
-table.dataTable thead .sorting_desc_disabled span:before {
-    right: -1.5rem;
-    content: "\2191";
-    position: absolute;
-}
-
-#dataTable thead .sorting span:before,
-#dataTable thead .sorting span:after,
-#dataTable thead .sorting_asc span:before,
-#dataTable thead .sorting_asc span:after,
-#dataTable thead .sorting_desc span:before,
-#dataTable thead .sorting_desc span:after,
-#dataTable thead .sorting_asc_disabled span:before,
-#dataTable thead .sorting_asc_disabled span:after,
-#dataTable thead .sorting_desc_disabled span:before,
-#dataTable thead .sorting_desc_disabled span:after {
-    opacity: 0;
-}
-
-#dataTable thead .sorting_asc span:before,
-#dataTable thead .sorting_desc span:after {
-    opacity: 1;
 }


### PR DESCRIPTION
This is related to the issue #ENG-568 and it adds a new system to show the sort icons on the table columns to the right of the titles. 

![image](https://user-images.githubusercontent.com/14981468/79133507-6d4f9380-7dac-11ea-8fa0-a6dc1c09de79.png)

![image](https://user-images.githubusercontent.com/14981468/79133530-76406500-7dac-11ea-973d-b968c597a8c2.png)

It also removes the sorting from the first column and adds a new order by default, sorting them by creation date as required by @warenlg.

![image](https://user-images.githubusercontent.com/14981468/79133469-5dd04a80-7dac-11ea-8031-4ec4ba314e84.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>