### PR TITLE
Hover effect on table headers

### DIFF
--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -52,6 +52,17 @@
                 &:before {
                     opacity: 0 !important;
                 }
+
+                &:hover {
+
+                    &:after {
+                        content: '\2191' !important;
+                        position: static;
+                        display: inline;
+                        margin-left: 1rem;
+                        opacity: 0.7 !important;
+                    }
+                }
             }
 
             &.sorting_desc,


### PR DESCRIPTION
This is related to the issue [#ENG-508](https://athenianco.atlassian.net/browse/ENG-508) and it also includes the changes of #226 as were required to do this one.

It adds a hover effect on the table headers:

![image](https://user-images.githubusercontent.com/14981468/79136908-0e8d1880-7db2-11ea-8365-564dfe11ab7f.png)
