### PR TITLE
Fix how Reviewed Review Summary Metric is calculated

### DIFF
--- a/docs/SummaryMetrics.md
+++ b/docs/SummaryMetrics.md
@@ -14,15 +14,15 @@ Design doc at https://docs.google.com/document/d/1DXLVz4L1Ag9sOUMAKdRRgVh1fk6peU
 ## WIP
 - Created PRs: pull requests created
   ```
-  prs.filter(from<pr.created<to).count
+  prs.filter(from<pr.created).count
   ```
 - Contributors: Number of people that have created pull requests during the period selected
   ```
-  prs.filter(from<pr.created<to).creators.distinct.count
+  prs.filter(from<pr.created).creators.distinct.count
   ```
 - Repos: where commits have been pushed during the time period selected
   ```
-  prs.filter(from<pr.created<to).repos.distinct.count
+  prs.filter(from<pr.created).repos.distinct.count
   ```
 
 ## Review

--- a/docs/SummaryMetrics.md
+++ b/docs/SummaryMetrics.md
@@ -28,7 +28,7 @@ Design doc at https://docs.google.com/document/d/1DXLVz4L1Ag9sOUMAKdRRgVh1fk6peU
 ## Review
 - Reviewed PRs: Pull requests where a review has been submitted or a regular comment posted
   ```
-  prs.filter(pr.stage>=review).having(comments|reviews).count
+  prs.filter(pr.stage>=review).having(OR[comments|review_comments,properties.oneOf(review|approve|changes_request)]).count
   ```
 - Reviewers: authors of one review or regular comment among the Reviewed PRs
   ```

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -195,19 +195,17 @@ export default ({ stage, data }) => {
                                     `events:[${row.properties.map(prop => prop.replace('_happened', '')).join(', ')}],\n` +
                                     `stage-completes:[${row.completedStages.join(', ')}]`;
                                 return (
-                                    `<div class="badge badge-outlined ${prLabelClasses[prLabelStage(row)]}">
-                                        <span
-                                            title="${hint}"
-                                            data-toggle="tooltip"
-                                            data-placement="bottom"
-                                            className="ml-2"
-                                        >
+                                    `<div title="${hint}" class="badge badge-outlined ${prLabelClasses[prLabelStage(row)]}">
+                                        <span data-toggle="tooltip" data-placement="bottom" className="ml-2">
                                             ${prLabelStage(row)}
                                         </span>
                                     </div>`
                                 );
-                            default:
+                            case 'filter':
                                 return row.properties.map(prop => prop.replace('_happened', '')).join(', ');
+                            case 'sort':
+                            case 'type':
+                                return prLabelStage(row);
                         }
                     },
                 },

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -32,7 +32,7 @@ const PR_STAGE_TIMELINE = [
     PR_STAGE.DONE,
 ];
 
-const PR_EVENT = {
+export const PR_EVENT = {
   CREATION: 'created',
   COMMIT: 'commit_happened',
   REVIEW_REQUEST: 'review_request_happened',
@@ -164,6 +164,8 @@ const extractStatus = pr => {
     return PR_STATUS.OPENED;
   }
 };
+
+export const happened = (pr, event) => pr.properties.includes(event);
 
 export const isInStage = (pr, stage) => (
     stageHappening(pr, stage) || stageHappened(pr, stage)


### PR DESCRIPTION
79a53c2 Fix how Reviewed Review Summary Metric is calculated:
Since some kind of reviews are not counted in `pr.comments` or `pr.review_comments`, this PR will also count as reviewed those PRs having at least one of the following `pr.properties`: `review`, `approve` or `changes_request`.

### minors
- 9f53731 Update docs about WIP stage. date_to is already considered by the API …
- 8c72834 Enhance PRs stage column:
  - Show tooltip in the whole button, not only when hovering the label text
  - Sort by shown label
