### PR TITLE
New colors for skipped and ignored review PRs

### DIFF
--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -81,9 +81,7 @@
             color: $color-review;
         }
 
-        &.label-review-rejected,
-        &.label-review-skipped,
-        &.label-review-ignored {
+        &.label-review-rejected {
             border-color: $color-red;
             color: $color-red;
         }
@@ -112,6 +110,16 @@
         &.label-closed {
             border-color: $color-secondary;
             color: $color-secondary;
+        }
+
+        &.label-review-skipped {
+            border-color: rgba($color-secondary,0.5);
+            color: rgba($color-secondary,0.5);
+        }
+
+        &.label-review-ignored {
+            border-color: rgba($color-dark, 0.8);
+            color: rgba($color-dark, 0.8);
         }
     }
 }


### PR DESCRIPTION
This is related to the issue [#ENG-576](https://athenianco.atlassian.net/browse/ENG-576).

It adds two new label colors for the **Not Reviewed** and **Review Ignored** PRs on the **Review** section.

![image](https://user-images.githubusercontent.com/14981468/79209717-139aa800-7e44-11ea-8585-fb7ca4f3b43d.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>