### PR TITLE
Just ensures that no error is raised in case unable to open installation link

### DIFF
--- a/src/js/pages/auth/Callback.jsx
+++ b/src/js/pages/auth/Callback.jsx
@@ -64,7 +64,9 @@ export default () => {
 
         if (invType === 'admin') {
           const win = window.open(window.ENV.application.githubAppUri, '_blank');
-          win.focus();
+          if (!!win) {
+                win.focus();
+          }
         }
 
         setRedirectTo(query.get('targetUrl'));


### PR DESCRIPTION
Related to [ENG-338](https://athenianco.atlassian.net/browse/ENG-338). This prevents raising the error and consequently preventing the redirect. In the meantime, in case the link doesn't open, we'll provide the installation link "by hand".