### PR TITLE
Fix start and enddate returned by date filter

### DIFF
--- a/src/js/components/ui/filters/DateInterval.jsx
+++ b/src/js/components/ui/filters/DateInterval.jsx
@@ -84,8 +84,8 @@ export default ({
 
         setPrevDateIntervalState(dateIntervalState);
         onChange({
-            from: dateIntervalState.startDate.valueOf(),
-            to: dateIntervalState.endDate.valueOf(),
+            from: dateIntervalState.startDate.startOf('day').valueOf(),
+            to: dateIntervalState.endDate.endOf('day').valueOf(),
         });
     }, [dateIntervalState, prevDateIntervalState, validateOrFix, focusedInputState, onChange]);
 


### PR DESCRIPTION
Otherwise `react-dates` returns the midday.