### PR TITLE
Title Overview Summary Metric as 'Lead Time'

### DIFF
--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -15,7 +15,7 @@ export const SummaryMetrics = ({ conf, chart, kpi }) => {
       <div className="card-body">
         <div className="row">
           <div className="col-4">
-            <header className="font-weight-bold text-lg mt-2">{conf.title}</header>
+            <header className="font-weight-bold text-lg mt-2">{conf.summaryMetricTitle || conf.title}</header>
             <div className="pl-2">
               <div className="font-weight-bold mt-4 mb-3 pb-2 border-bottom">
                 <BigNumber content={dateTime.human(conf.avg)} isXL />

--- a/src/js/pages/pipeline/Pipeline.jsx
+++ b/src/js/pages/pipeline/Pipeline.jsx
@@ -15,7 +15,8 @@ const distinct = (collection, extractor) => Array.from(new Set(collection.flatMa
 
 export const pipelineStagesConf = [
     {
-        title: 'Lead Time',
+        title: 'Overview',
+        summaryMetricTitle: 'Lead Time',
         slug: 'overview',
         metric: 'lead-time',
         stageName: 'leadtime',


### PR DESCRIPTION
[[ENG-589]] Fix Overview in the breadcrumb menu
caused by https://github.com/athenianco/athenian-webapp/pull/228

![image](https://user-images.githubusercontent.com/2437584/79268677-73706d80-7e9b-11ea-912f-ea18bd78efa7.png)

---

![image](https://user-images.githubusercontent.com/2437584/79268713-82efb680-7e9b-11ea-94d4-e01a3d7f7caf.png)



[ENG-589]: https://athenianco.atlassian.net/browse/ENG-589