### PR TITLE
Fix user registration callback that requires refresh

### DIFF
--- a/src/js/ContextRoute.jsx
+++ b/src/js/ContextRoute.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+
+export default ({ context, children, ...rest }) => {
+    const Provider = context;
+
+    return (
+        <Route {...rest}>
+          <Provider>
+            {children}
+          </Provider>
+        </Route>
+    );
+};

--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
 import {
-  Router,
-  Switch,
-  Route,
-  Redirect,
+    Router,
+    Switch,
+    Route,
+    Redirect,
 } from 'react-router-dom';
 
 import history from 'js/services/history';
 
 import PrivateRoute from 'js/PrivateRoute';
+import ContextRoute from 'js/ContextRoute';
 
 import Home from 'js/pages/Home';
 import UserContext from 'js/context/User';
@@ -30,66 +31,75 @@ import Tooltips from 'js/pages/prototypes/Tooltips';
 
 export default () => {
 
-  const devmode = (
-    process.env.NODE_ENV === 'development' ||
-    ['development', 'staging'].includes(window.ENV.environment)
-  );
+    const devmode = (
+        process.env.NODE_ENV === 'development' ||
+            ['development', 'staging'].includes(window.ENV.environment)
+    );
 
-  return (
-    <React.StrictMode>
-      <Router history={history}>
-        <UserContext>
-          <Switch>
-            <Route exact path='/'>
-              <Home />
-            </Route>
-            <Route path='/stage/:name?'>
-              <Pipeline>
-                <Switch>
-                  <Route exact path='/stage'>
-                    <Redirect to='/stage/overview' />
-                  </Route>
-                  <Route exact path='/stage/overview'>
-                    <Overview />
-                  </Route>
-                  <Route path='/stage/:name'>
-                    <Stage />
-                  </Route>
-                </Switch>
-              </Pipeline>
-            </Route>
-            <Route path='/i/:code(\w{8})'>
-              <Redirect to={
-                {
-                  pathname: '/login',
-                  state: { inviteLink: window.location.href }
-                }
-              } />
-            </Route>
-            <Route path='/callback'>
-              <Callback />
-            </Route>
-            <Route path='/login'>
-              <Login />
-            </Route>
-            <Route path='/logout'>
-              <Logout />
-            </Route>
-            {devmode && <Route path='/bearer'><Development.Bearer /></Route>}
-            <PrivateRoute path='/waiting' component={Waiting} />
-            <Route path='/prototypes/:name?'>
-              <Prototypes prototypes={{
-                'charts': <Charts />,
-                'metrics-groups': <MetricGroups />,
-                'tooltips': <Tooltips />,
-              }} />
-            </Route>
-            <Route path='*'>
-              <NotFound404 />
-            </Route>
-          </Switch>
-        </UserContext>
-      </Router>
-    </React.StrictMode>
-  );
+    return (
+        <React.StrictMode>
+          <Router history={history}>
+            <Switch>
+
+              <ContextRoute context={UserContext} exact path='/'>
+                <Home />
+              </ContextRoute>
+
+              <ContextRoute context={UserContext} path='/stage/:name?'>
+                <Pipeline>
+                  <Switch>
+                    <Route exact path='/stage'>
+                      <Redirect to='/stage/overview' />
+                    </Route>
+                    <Route exact path='/stage/overview'>
+                      <Overview />
+                    </Route>
+                    <Route path='/stage/:name'>
+                      <Stage />
+                    </Route>
+                  </Switch>
+                </Pipeline>
+              </ContextRoute>
+
+              <Route path='/i/:code(\w{8})'>
+                <Redirect to={
+                    {
+                        pathname: '/login',
+                        state: { inviteLink: window.location.href }
+                    }
+                } />
+              </Route>
+
+              <Route path='/callback'>
+                <Callback />
+              </Route>
+
+              <Route path='/login'>
+                <Login />
+              </Route>
+
+              <ContextRoute context={UserContext} path='/logout'>
+                <Logout />
+              </ContextRoute>
+
+              {devmode && <Route path='/bearer'><Development.Bearer /></Route>}
+
+              <PrivateRoute path='/waiting' component={Waiting} />
+
+              <Route path='/prototypes/:name?'>
+                <Prototypes prototypes={{
+                    'charts': <Charts />,
+                    'metrics-groups': <MetricGroups />,
+                    'tooltips': <Tooltips />,
+                }} />
+              </Route>
+
+              <Route path='*'>
+                <NotFound404 />
+              </Route>
+
+            </Switch>
+          </Router>
+        </React.StrictMode>
+    );
 };


### PR DESCRIPTION
This PR fixes the bug that requires a manual reload of the page after registration.

The problem was that the `UserContext` was used also by the `/callback` route. The component corresponding to the `/callback` route was calling the endpoint for accepting the invitation and then redirecting to the home page. The problem is that since the `UserContext` was wrapping all the routes, the `userState` was not re-computed when redirecting to the home page, hence no accounts were associated and filters weren't working due to missing `account` parameter.