### PR TITLE
Enhance user flow experience

### DIFF
--- a/src/js/pages/Waiting.jsx
+++ b/src/js/pages/Waiting.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import Simple from './templates/Simple';
+import Page from './templates/Page';
 
 import { useUserContext } from 'js/context/User';
+
+import logo from 'images/logos/logo-transparent.svg';
 
 export default () => {
   const location = useLocation();
@@ -30,47 +32,69 @@ export default () => {
 
   if (!isAdmin) {
     return (
-      <Simple linkToHome={false}>
-        <Loading />
-      </Simple>
+      <Slide
+        title="Welcome to Athenian"
+        text="Please wait while we are fetching your data…"
+      >
+        <Welcome />
+      </Slide>
     )
   }
 
   if (!autoOpen) {
     return (
-      <Simple linkToHome={false}>
-        <Loading />
-        <div>To install and configure the GH application, open <GhAppLink url={ghAppUrl} /></div>
-      </Simple>
+      <Slide
+        title="Welcome to Athenian"
+        text="Please wait while we are fetching your data…"
+        footer={<>To install and configure the GitHub application, open <GhAppLink url={ghAppUrl} /></>}
+      >
+        <Welcome />
+      </Slide>
     );
   }
 
   if (ghAppOpenErrorState) {
     return (
-      <Simple linkToHome={false}>
-        <div>Please, install and configure the Athenian GH application at <GhAppLink url={ghAppUrl} /></div>
-        <WillLoad />
-      </Simple>
+      <Slide
+        title="Install Athenian GitHub Application"
+        text={
+          <>
+            <div>
+              Please, install and configure the Athenian GitHub application
+              at <GhAppLink url={ghAppUrl} onClick={() => setGhAppOpenedState(true)} />
+            </div>
+            <div className="mt-2">
+              Once you install and configure the GitHub App, Athenian will start loading your data from GitHub. The loading process will take a while.
+            </div>
+          </>
+        }
+        footer="The Athenian GitHub application could not be automatically opened"
+      />
     );
   }
 
   if (!ghAppOpenedState) {
     return (
-      <Simple linkToHome={false}>
-        <div>Another tab is going to be opened to install and configure the GH application;</div>
-        <div>
-          if it doesn’t, please open <GhAppLink url={ghAppUrl} onClick={() => setGhAppOpenedState(true)} />
-        </div>
-      </Simple>
+      <Slide
+        title="Install Athenian GitHub Application"
+        text={
+          <>
+            Another tab is going to be opened to install and configure the GitHub application
+            if it doesn’t, please open <GhAppLink url={ghAppUrl} onClick={() => setGhAppOpenedState(true)} />
+          </>
+        }
+      />
     );
   }
 
   return (
-    <Simple linkToHome={false}>
-      <Loading />
-      <div>You can install and configure the GH application in the recently opened tab.</div>
-      <div>You can open it again <GhAppLink url={ghAppUrl} /></div>
-    </Simple>
+    <Slide
+      title="Welcome to Athenian"
+      text="Please wait while we are fetching your data…"
+      footer={<>Install and configure the GitHub application in the recently opened tab, or through <GhAppLink url={ghAppUrl} /></>}
+    >
+      <Welcome />
+    </Slide>
   );
 };
 
@@ -90,18 +114,67 @@ const openGhApp = (url, onOpen, onError) => {
   }
 }
 
-const Loading = () => {
-  return (
-    <div className="mb-2">We are loading your data from GitHub, this is going to take a while.</div>
-  );
-};
-
-const WillLoad = () => {
-  return (
-    <div>Once you install and configure the GitHub App, Athenian will start loading your data from GitHub. The loading process will take a while.</div>
-  );
-};
-
 const GhAppLink = ({ url, ...rest }) => (
   <a href={url} target="_blank" rel="noopener noreferrer" {...rest}>{url}</a>
 );
+
+const Slide = ({ title, text, footer, children }) => {
+  return (
+    <Page>
+      <div className="row h-100">
+        <div className="col-12 my-auto">
+          <div className="mt-3 mb-5 text-center">
+            <img src={logo} alt="" width="200" />
+          </div>
+          <div className="col-8 offset-2 mb-5">
+            <div className="card waiting py-5">
+              <div className="card-body py-5">
+                <div className="row">
+                  <div className="col">
+                    <h2 className="h1 text-dark font-weight-normal mt-5 mb-2 pl-4">{title}</h2>
+                    <p className="h4 text-secondary font-weight-light pl-4 mb-5">{text}</p>
+                    {children}
+                  </div>
+                </div>
+              </div>
+            </div>
+            {footer && (
+              <div>
+                {footer}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </Page>
+  );
+};
+
+const Welcome = () => {
+  return (
+    <div className="pl-4">
+      <ul className="m-0 p-0">
+        <li className="waiting-container mb-1">
+          <div className="waiting-chart">
+            <span className="waiting-box"></span>
+          </div>
+        </li>
+        <li className="waiting-container mb-1">
+          <div className="waiting-table">
+            <span className="waiting-box"></span>
+          </div>
+        </li>
+        <li className="waiting-container mb-1">
+          <div className="waiting-table">
+            <span className="waiting-box"></span>
+          </div>
+        </li>
+        <li className="waiting-container mb-1">
+          <div className="waiting-table">
+            <span className="waiting-box"></span>
+          </div>
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/src/js/pages/Waiting.jsx
+++ b/src/js/pages/Waiting.jsx
@@ -1,21 +1,107 @@
-import React, { useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import Simple from './templates/Simple';
 
+import { useUserContext } from 'js/context/User';
+
 export default () => {
-  const history = useHistory();
+  const location = useLocation();
+  const userContext = useUserContext();
+  const [ghAppOpenedState, setGhAppOpenedState] = useState(false);
+  const [ghAppOpenErrorState, setGhAppOpeneErrorState] = useState(false);
+
+  const ghAppUrl = window.ENV.application.githubAppUri;
 
   useEffect(() => {
+    if (!location.state?.ghAppAutoOpen) {
+      return;
+    }
+
     const timer = setTimeout(() => {
-      history.push('/');
-    }, 30000);
+      !ghAppOpenedState && openGhApp(ghAppUrl, () => setGhAppOpenedState(true), () => setGhAppOpeneErrorState(true))
+    }, 5000);
+
     return () => clearTimeout(timer);
-  }, [history]);
+  }, [ghAppOpenedState, location.state, ghAppUrl]);
+
+  const isAdmin = userContext?.defaultAccount?.isAdmin;
+  const autoOpen = location.state?.ghAppAutoOpen;
+
+  if (!isAdmin) {
+    return (
+      <Simple linkToHome={false}>
+        <Loading />
+      </Simple>
+    )
+  }
+
+  if (!autoOpen) {
+    return (
+      <Simple linkToHome={false}>
+        <Loading />
+        <div>To install and configure the GH application, open <GhAppLink url={ghAppUrl} /></div>
+      </Simple>
+    );
+  }
+
+  if (ghAppOpenErrorState) {
+    return (
+      <Simple linkToHome={false}>
+        <div>Please, install and configure the Athenian GH application at <GhAppLink url={ghAppUrl} /></div>
+        <WillLoad />
+      </Simple>
+    );
+  }
+
+  if (!ghAppOpenedState) {
+    return (
+      <Simple linkToHome={false}>
+        <div>Another tab is going to be opened to install and configure the GH application;</div>
+        <div>
+          if it doesn’t, please open <GhAppLink url={ghAppUrl} onClick={() => setGhAppOpenedState(true)} />
+        </div>
+      </Simple>
+    );
+  }
 
   return (
     <Simple linkToHome={false}>
-      We are loading your data from GitHub, this is going to take a while.
+      <Loading />
+      <div>You can install and configure the GH application in the recently opened tab.</div>
+      <div>You can open it again <GhAppLink url={ghAppUrl} /></div>
     </Simple>
   );
 };
+
+const openGhApp = (url, onOpen, onError) => {
+  const ghAppWindow = window.open(url, '_blank');
+  if (!ghAppWindow?.focus) {
+    onError();
+    return;
+  }
+
+  try {
+    ghAppWindow.focus();
+    onOpen();
+  } catch (e) {
+    console.error(e);
+    onError();
+  }
+}
+
+const Loading = () => {
+  return (
+    <div className="mb-2">We are loading your data from GitHub, this is going to take a while.</div>
+  );
+};
+
+const WillLoad = () => {
+  return (
+    <div>Once you install and configure the GitHub App, Athenian will start loading your data from GitHub. The loading process will take a while.</div>
+  );
+};
+
+const GhAppLink = ({ url, ...rest }) => (
+  <a href={url} target="_blank" rel="noopener noreferrer" {...rest}>{url}</a>
+);

--- a/src/js/pages/auth/Login.jsx
+++ b/src/js/pages/auth/Login.jsx
@@ -1,47 +1,38 @@
 import React from 'react';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { Link, useLocation, Redirect } from 'react-router-dom';
 
 import { useAuth0 } from 'js/context/Auth0';
 import Simple from 'js/pages/templates/Simple';
 
 export default () => {
-  const history = useHistory();
   const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
   const location = useLocation();
+  const inviteLink = location.state?.inviteLink;
 
   if (loading) {
     return <Simple>Loading...</Simple>;
   }
 
   if (isAuthenticated) {
-    if (location.state && location.state.inviteLink) {
-      return (
+    return inviteLink ?
+      (
         <Simple>
           You must <Link to="/logout">logout</Link> first, and then open the invitation link.
         </Simple>
-      )
-    }
-
-    history.push('/');
-  }
-
-  const appState = {
-    targetUrl: '/',
-  };
-
-  if (location.state && location.state.inviteLink) {
-    appState.inviteLink = location.state.inviteLink;
+      ) : (
+        <Redirect to={{ pathname: '/' }} />
+      );
   }
 
   return (
     <Simple>
-      {location.state && location.state.inviteLink && (
-        <p>Login to accept invitation {appState.inviteLink}</p>
+      {inviteLink && (
+        <p>Login to accept invitation {inviteLink}</p>
       )}
       <button
         type="button"
         className="btn btn-primary btn-lg"
-        onClick={() => loginWithRedirect({ appState: appState })}
+        onClick={() => loginWithRedirect({ appState: { inviteLink } })}
       >
         Login
       </button>

--- a/src/sass/components/_waiting.scss
+++ b/src/sass/components/_waiting.scss
@@ -48,6 +48,7 @@
 .waiting {
     background: url(../../images/waiting-bg.svg) no-repeat right bottom $white !important;
     background-size: 50% !important;
+    min-height: 425px;
 
     &-container {
         display: flex;
@@ -63,6 +64,10 @@
         background: url(../../images/table-default.svg) left center no-repeat transparent;
         height: 30px;
         width: 300px;
+    }
+
+    .card-body {
+        max-width: 540px;;
     }
 }
 


### PR DESCRIPTION
solves [[ENG-338]] During registration callback, opening the Athenian GitHub app installation tab could raise an error

- Once the process of accepting an admin-invitation succeeds, it is noticed to the user that Athenian GitHub App page will be opened in a new tab
- In 5s, the new tab with App URL will be automatically opened and focused.
- It will be shown the waiting message if any of the following happens:
  - https://github.com/apps/athenian-owl is automatically opened and focused with no issue,
  - when the Athenian GitHub APP tab can not be opened or focused,
  - the user manually clicks in the link of the Athenian GitHub app https://github.com/apps/athenian-owl,

This PR uses the prototyped waiting page as defined by https://github.com/athenianco/athenian-webapp/pull/245

### A regular user enters into the waiting page (after registration or by direct link)
- Nothing happens, the waiting page keeps this way forever.
- There is no link to Athenian GitHub App.
![image](https://user-images.githubusercontent.com/2437584/79696134-05e98600-827b-11ea-836c-7647b69a693a.png)


### An admin lands into the waiting page (only direct link, not after registration)
- Nothing happens, the waiting page keeps this way forever.
- There is a link to Athenian GitHub App to let the admin configure it.
![image](https://user-images.githubusercontent.com/2437584/79696085-c753cb80-827a-11ea-88a7-967a803fa14c.png)


### An admin accepts the invitation and enters the waiting page
- It is announced that a new tab will be opened to let the Admin install and configure the Athenian GitHub App.
- The Athenian GitHub App page will be automatically open and focused after 5s.
- If the Admin manually opens the Athenian GitHub App before the 5s waiting, no extra tab will be opened.
![image](https://user-images.githubusercontent.com/2437584/79696239-dab36680-827b-11ea-8f58-92b6cd2d3b80.png)


### The GH APP page is successfully (and automatically) opened and focused
- Shown once the Athenian GitHub App page is opened (after the 5s waiting, or manually opened).
- Nothing more happens, the waiting page keeps this way forever.
- There is a link to Athenian GitHub App to let the admin configure it in case they closed the new tab before installing the App.
![image](https://user-images.githubusercontent.com/2437584/79696113-ee120200-827a-11ea-9345-5e4874df7bad.png)


### The GH APP page can not be opened and focused (as in the issue)
- Shown if the Athenian GitHub App page could not be automatically opened and focused.
- It is announced that the import process will start after the Athenian GitHub App is installed.
- Once the user clicks in the Athenian GitHub App link, the waiting message will change as when the page is automatically opened.
![image](https://user-images.githubusercontent.com/2437584/79696244-e3a43800-827b-11ea-9988-1cc4e51b5dd1.png)



[ENG-338]: https://athenianco.atlassian.net/browse/ENG-338