### PR TITLE
Mini charts squash requests

### DIFF
--- a/src/js/components/DataWidget.jsx
+++ b/src/js/components/DataWidget.jsx
@@ -49,23 +49,29 @@ export default ({id, component, fetcher, plumber, config, propagateSpinner = fal
     }, [id, getData, prevLoadingDataState, loadingDataState]);
 
     const waiting = !dataState;
-    const margin = conf.margin !== undefined ? conf.margin : 5;
-    const spinner = (
-        <div className={`row mt-${margin} mb-${margin} align-middle`}>
-          <div className="col-12 text-center">
-            <Spinner loading={true} color={conf.color || 'black'} />
-          </div>
-        </div>
-    );
+    const spinner = buildSpinner(conf);
 
     if (waiting && !propagateSpinner) {
         return spinner;
     }
 
     if (propagateSpinner) {
+        // this should be uniformed, not done yet for backward compatibility
         conf.spinner = spinner;
+        conf.spinnerBuilder = buildSpinner;
     }
 
     const Component = component;
     return <Component data={dataState} loading={waiting} {...conf} />;
+};
+
+const buildSpinner = (conf) => {
+    const margin = conf.margin !== undefined ? conf.margin : 5;
+    return (
+        <div className={`row mt-${margin} mb-${margin} mx-auto align-middle`}>
+          <div className="col-12 text-center">
+            <Spinner loading={true} color={conf.color || 'black'} />
+          </div>
+        </div>
+    );
 };

--- a/src/js/components/pipeline/PipelineCardMiniChart.jsx
+++ b/src/js/components/pipeline/PipelineCardMiniChart.jsx
@@ -1,39 +1,8 @@
 import React from 'react';
 
-import { fetchPRsMetrics } from 'js/services/api/index';
-
-import { useApi } from 'js/hooks';
-
 import CleanAreaChart, { vertical } from 'js/components/charts/CleanAreaChart';
-import DataWidget from 'js/components/DataWidget';
 
-import moment from 'moment';
-import _ from "lodash";
-
-export default ({name, metric, config}) => {
-    const { api, ready: apiReady, context: apiContext } = useApi();
-
-    if (!apiReady) {
-        return null;
-    }
-
-    const { account, interval, repositories, contributors: developers } = apiContext;
-    const granularity = calculateGranularity(interval);
-
-    const fetcher = async () => {
-        return fetchPRsMetrics(
-            api, account, granularity, interval, [metric],
-            { repositories, developers }
-        );
-    };
-
-    const plumber = (data) => _(data.calculated[0].values)
-          .map(v => ({
-              x: v.date,
-              y: v.values[0] || 0
-          }))
-          .value();
-
+export default ({data, config}) => {
     const color = config.color;
     const fill = {
         direction: vertical,
@@ -67,29 +36,5 @@ export default ({name, metric, config}) => {
         ]
     };
 
-    const defaultConfig = {fill, stroke};
-    const chartConfig = {...defaultConfig, ...config};
-
-    return (
-        <DataWidget
-          id={`pipeline-card-mini-chart-${name}`}
-          component={CleanAreaChart} fetcher={fetcher} plumber={plumber}
-          config={chartConfig}
-        />
-    );
-};
-
-const calculateGranularity = (interval) => {
-    console.log(interval);
-    const diff = moment(interval.to).diff(interval.from, 'days');
-
-    if (diff <= 21) {
-        return 'day';
-    }
-
-    if (diff <= 90) {
-        return 'week';
-    }
-
-    return 'month';
+    return <CleanAreaChart fill={fill} stroke={stroke} data={data}/>;
 };

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -6,41 +6,80 @@ import Badge, { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 import { BigNumber, SmallTitle } from 'js/components/ui/Typography';
 import Info from 'js/components/ui/Info';
 import PipelineCardMiniChart from 'js/components/pipeline/PipelineCardMiniChart';
-
 import { dateTime, number } from 'js/services/format';
+import DataWidget from 'js/components/DataWidget';
+import { useApi } from 'js/hooks';
+import { fetchPRsMetrics } from 'js/services/api/index';
+import { pipelineStagesConf, getStage } from 'js/pages/pipeline/Pipeline';
+import moment from 'moment';
+import _ from "lodash";
 
-export default ({ prs, stages, activeCard }) => {
-    return (
-        <div className="row mt-4 mb-4 align-items-end pipeline-thumbnails">
-            {
-                stages.map(
-                    (card, i) => (
-                        <div className={classnames('col-md-3 pipeline-stage', card.stageName, activeCard === card.slug && 'active')} key={i}>
-                            <span data-toggle="tooltip" data-placement="bottom" title={card.event.before} className="event-before" />
-                            <Link to={'/stage/' + card.slug}>
-                                <Stage
-                                    title={card.title}
-                                    text={card.avg && dateTime.human(card.avg)}
-                                    hint={card.hint}
-                                    variation={card.variation}
-                                    color={card.color}
-                                    name={card.stageName}
-                                    metric={card.metric}
-                                    active={activeCard === card.slug}
-                                    badge={card.stageCompleteCount(prs)}
-                                >
-                                </Stage>
-                            </Link>
-                            <span data-toggle="tooltip" data-placement="bottom" title={card.event.after} className="event-after" />
-                        </div>
-                    )
-                )
-            }
-        </div>
+const Thumbnails = ({ data, loading, spinnerBuilder, prs, stages, activeCard }) => (
+    <div className="row mt-4 mb-4 align-items-end pipeline-thumbnails">
+      {
+          // Here we're iterating on `pipelineStagesConf` so that we can already
+          // draw the UI even without the data. This has to be refactored in order to not
+          // use both `pipelineStagesConf` and `stages` since `stages` is the same thing,
+          // but just with the data populated.
+          pipelineStagesConf.slice(2, pipelineStagesConf.length).map(
+              (card, i) => {
+                  const allReady = !loading && prs.length > 0 && stages.length > 0;
+                  const spinner = spinnerBuilder({
+                      margin: 0,
+                      color: card.color
+                  });
+
+                  let [stageData, textValue, variationValue, completedPRs] = [null, null, null, null];
+                  if (allReady) {
+                      const computedCard = getStage(stages, card.slug);
+                      stageData = data[card.metric];
+                      textValue = computedCard.avg && dateTime.human(computedCard.avg);
+                      variationValue = computedCard.variation;
+                      completedPRs = computedCard.stageCompleteCount(prs);
+                  }
+
+                  return (
+                      <div className={classnames('col-md-3 pipeline-stage', card.stageName, activeCard === card.slug && 'active')} key={i}>
+                        <span data-toggle="tooltip" data-placement="bottom" title={card.event.before} className="event-before" />
+                        <Link to={'/stage/' + card.slug}>
+                          <Stage
+                            data={stageData}
+                            loading={!allReady}
+                            spinner={spinner}
+                            title={card.title}
+                            text={textValue}
+                            hint={card.hint}
+                            variation={variationValue}
+                            color={card.color}
+                            active={activeCard === card.slug}
+                            badge={completedPRs}
+                          >
+                          </Stage>
+                        </Link>
+                        <span data-toggle="tooltip" data-placement="bottom" title={card.event.after} className="event-after" />
+                      </div>
+                  );
+              }
+          )
+      }
+    </div>
+);
+
+
+const Stage = ({ data, loading, spinner, title, text, hint, badge, variation, color, active, onClick }) => {
+    const content = loading ? spinner : (
+        <>
+          <div className="col-5">
+            <BigNumber content={text} className="mb-1 w-100" />
+            {text ? <Badge trend={NEGATIVE_IS_BETTER} value={number.round(variation)} /> : ''}
+          </div>
+          <div className="col-7 pl-2" style={{ height: 55 }}>
+            <PipelineCardMiniChart data={data} config={{
+                color: active ? '#FFFFFF' : color
+            }} />
+          </div>
+        </>
     );
-};
-
-const Stage = ({ title, text, hint, badge, variation, color, name, metric, active, onClick }) => {
     return (
         <div className={classnames('card pipeline-thumbnail', active && 'active')} onClick={onClick}>
             <div className="card-body p-3">
@@ -49,20 +88,68 @@ const Stage = ({ title, text, hint, badge, variation, color, name, metric, activ
                         <SmallTitle content={title} />
                         <Info content={hint} />
                     </span>
-                    {badge && <Badge value={badge} />}
+                    {!loading && badge && <Badge value={badge} />}
                 </div>
                 <div className="row no-gutters card-text">
-                    <div className="col-5">
-                        <BigNumber content={text} className="mb-1 w-100" />
-                        {text ? <Badge trend={NEGATIVE_IS_BETTER} value={number.round(variation)} /> : ''}
-                    </div>
-                    <div className="col-7 pl-2" style={{ height: 55 }}>
-                      <PipelineCardMiniChart name={name} metric={metric} config={{
-                          color: active ? '#FFFFFF' : color
-                      }} />
-                    </div>
+                  {content}
                 </div>
             </div>
         </div>
     );
+};
+
+export default ({prs, stages, activeCard, config = {}}) => {
+    const { api, ready: apiReady, context: apiContext } = useApi();
+
+    if (!apiReady) {
+        return null;
+    }
+
+    const { account, interval, repositories, contributors: developers } = apiContext;
+    const granularity = calculateGranularity(interval);
+    const metrics = ['wip-time', 'review-time', 'merging-time', 'release-time'];
+
+    const fetcher = async () => fetchPRsMetrics(
+        api, account, granularity, interval, metrics,
+        { repositories, developers }
+    );
+
+    const plumber = (data) => _(data.calculated[0].values)
+          .reduce(function(result, datapoint) {
+              _(metrics).each((metric, i) => {
+                  result[metric] = result[metric] || [];
+                  result[metric].push({
+                      x: datapoint.date,
+                      y: datapoint.values[i]
+                  });
+              });
+
+              return result;
+          }, {});
+
+    const defaultConfig = {prs, stages};
+    const chartConfig = {...config, ...defaultConfig, margin: 0};
+
+    return (
+        <DataWidget
+          id={`pipeline-cards-mini-charts`}
+          component={Thumbnails} fetcher={fetcher} plumber={plumber}
+          propagateSpinner={true}
+          config={chartConfig}
+        />
+    );
+};
+
+const calculateGranularity = (interval) => {
+    const diff = moment(interval.to).diff(interval.from, 'days');
+
+    if (diff <= 21) {
+        return 'day';
+    }
+
+    if (diff <= 90) {
+        return 'week';
+    }
+
+    return 'month';
 };


### PR DESCRIPTION
This PR optimizes the calls made to render the mini-charts. Instead of doing 4 separate requests, this PR will now do a single one for all 4 metrics. Side effects:
- the whole row is loaded "at once", but with the skeleton already there
- even if on each filter change the spinner appears, there's still a glitch for the data on the left (the number and the badge variation) as those are data "injected" from outside and not requested by the mini-chart component. I'd rather address this separately as it's part of a bigger change since for now there's not way to know whether those data injected from outside the component are ready or not.

## Gif*

![mini-charts-loading-opt](https://user-images.githubusercontent.com/5599208/79771298-e318a980-832e-11ea-8a6b-fdc2927f90a8.gif)

_*done at 5x speed locally_
