### PR TITLE
Consistency

### DIFF
--- a/src/js/components/insights/stages/review/reviewActivity.jsx
+++ b/src/js/components/insights/stages/review/reviewActivity.jsx
@@ -16,6 +16,7 @@ const reviewActivity = {
             const metrics = [
                 'reviews',
                 'prs-created',
+                'prs-reviewed',
             ];
 
             return fetchDevsMetrics(
@@ -52,6 +53,9 @@ const reviewActivity = {
         const totalPRsComments = _(fetched.secondBox.calculated)
               .map(v => v.values[0][1])
               .sum();
+        const totalReviewedPRs = _(fetched.firstBox.calculated)
+            .map(v => v.values[0][2])
+            .sum();
         const totalReviewers = _(fetched.secondBox.calculated)
             .filter(v => v.values[0][0] > 0)
             .value()
@@ -131,7 +135,7 @@ const reviewActivity = {
                     sumReviews: _(fetched.firstBox.calculated)
                         .map(v => v.values[0][0])
                         .sum(),
-                    avgReviewsPerDev: totalReviews / totalReviewers
+                    avgReviewedPRsPerDev: totalReviewedPRs / totalReviewers,
                 }
             },
             secondBox: {
@@ -188,7 +192,7 @@ const reviewActivity = {
                             subtitle: {text: 'Per Developer'},
                             component: SimpleKPI,
                             params: {
-                                value: computed.firstBox.KPIsData.avgReviewsPerDev.toFixed(2)
+                                value: computed.firstBox.KPIsData.avgReviewedPRsPerDev.toFixed(2)
                             }
                         },
                         {

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -121,7 +121,7 @@ export default ({ stage, data }) => {
                                     <div class="table-creators">
                                         ${row.authors.map(userImage(users)).join(' ')}
                                         <div class="pr-created-by"><span>Created by</span> <span class="text-dark">${row.authors.map(github.userName).join(' ')}</span>
-                                        <span>${dateTime.ago(row.created)} ago</span></div>
+                                        <span title="${dateTime.ymd(row.created)}">${dateTime.ago(row.created)} ago</span></div>
                                     </div>
                                 `;
                             case 'filter':

--- a/src/js/pages/pipeline/Pipeline.jsx
+++ b/src/js/pages/pipeline/Pipeline.jsx
@@ -60,11 +60,7 @@ export const pipelineStagesConf = [
         stageCompleteCount: prs => prs.filter(pr => pr.completedStages.includes(prStage.REVIEW)).length,
         summary: (stage, prs) => {
             const reviewAndReviewCompletePRs = prs.filter(pr => isInStage(pr, prStage.REVIEW));
-            const reviewed = reviewAndReviewCompletePRs.filter(pr => {
-                if (pr.comments || pr.review_comments) {
-                    return true;
-                }
-
+            const reviewed = prs.filter(pr => {
                 return happened(pr, prEvent.REVIEW) || happened(pr, prEvent.REJECTION) || happened(pr, prEvent.APPROVE);
             });
 

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -140,12 +140,13 @@ const extractStageTimings = pr => _(pr.stage_timings)
 
 const extractParticipantsByKind = pr => pr.participants.reduce((acc, participant) => {
   const has_status = status => participant.status.includes(status);
-  if (has_status('author')) {
-    acc.authors.push(participant.id);
-  }
-
   if (has_status('merger')) {
     acc.mergers.push(participant.id);
+  }
+
+  if (has_status('author')) {
+    acc.authors.push(participant.id);
+    return acc;
   }
 
   if (has_status('reviewer') || has_status('commenter')) {


### PR DESCRIPTION
required by [[ENG-489]]

different improvements:
- bc11c6b Ensure that AVG reviewed PRs per dev count does not count multiple reviews in the same PR
- 1786476 Consider 'Reviewed' a PR only when review, rejection or approval events are present. Closed PRs having these events should be also considered as reviewed.
- 4045bcc Reviewed PRs must count unique PRs instead of sum the reviews made per developer, which can be made over the same PR

Improvements that I needed while fixing inconsistencies between Summary Metrics and Review Activity KPIs
- 83030c9 Exclude authors from commenters or reviewers in PRs table
- 26c1e7e Show created date in a tooltip over 'created ago' text in PR tables …


[ENG-489]: https://athenianco.atlassian.net/browse/ENG-489