### PR TITLE
Main metrics requests improvement

### DIFF
--- a/src/js/components/insights/Insights.jsx
+++ b/src/js/components/insights/Insights.jsx
@@ -20,7 +20,7 @@ const stageChartsStateReducer = (state, action) => {
 };
 
 export default () => {
-    const { curr: prsContext } = usePRsContext();
+    const prsContext = usePRsContext();
     const { api, ready: apiReady, context: apiContext } = useApi();
     const { name: stageSlug } = useParams();
 

--- a/src/js/context/Data.jsx
+++ b/src/js/context/Data.jsx
@@ -4,27 +4,48 @@ const DataContext = React.createContext({});
 
 export const useDataContext = () => useContext(DataContext);
 
+const globalKeysWhitelist = [
+    'filter.repos',
+    'filter.contribs',
+    'prs'
+];
+
+const globalKeyPrefix = 'global.';
+
 const dataStateReducer = (state, action) => {
     if (action.reset) {
         console.log("Resetting all data");
         return {};
     }
 
-    const { id, data } = action;
-    console.log("Setting data with id: ", id);
-    state[id] = data;
+    const { id, data, global } = action;
+    console.log(`Setting ${global ? 'global ' : ''}data with id: ${id} | ${state[id]}`);
+    if (global) {
+        if (!globalKeysWhitelist.includes(id)) {
+            throw Error(`Trying to use unrecognized global id: ${id}`);
+        } else if (state[id]) {
+            throw Error(`Trying to override global data with id: ${id}`);
+        }
+    } else if (id.startsWith(globalKeyPrefix)) {
+        throw Error(`Non-global data cannot have id with prefix ${globalKeyPrefix}: ${id}`);
+    }
+
+    const prefix = global ? globalKeyPrefix : '';
+    state[`${prefix}${id}`] = data;
     return state;
 };
 
 export default ({ children }) => {
     const [dataState, dispatchDataState] = useReducer(dataStateReducer, {});
 
+    const reset = () => dispatchDataState({reset: true});
     const get = (id) => id ? dataState[id] : null;
     const set = (id, data) => id ? dispatchDataState({id, data}) : null;
-    const reset = () => dispatchDataState({reset: true});
+    const getGlobal = (id) => id ? dataState[`global.${id}`] : null;
+    const setGlobal = (id, data) => id ? dispatchDataState({id, data, global: true}) : null;
 
     return (
-        <DataContext.Provider value={{get, set, reset}}>
+        <DataContext.Provider value={{get, set, getGlobal, setGlobal, reset}}>
             {children}
         </DataContext.Provider >
     );

--- a/src/js/context/PRs.jsx
+++ b/src/js/context/PRs.jsx
@@ -1,9 +1,6 @@
 import React, { useContext } from 'react';
 
-const PRsContext = React.createContext({
-    prev: { prs: [], users: {} },
-    curr: { prs: [], users: {} },
-});
+const PRsContext = React.createContext({ prs: [], users: {} });
 
 /**
  * Returns the PRs (prs) and participants (users) within the active filters.
@@ -11,9 +8,9 @@ const PRsContext = React.createContext({
  */
 export const usePRsContext = () => useContext(PRsContext);
 
-export default ({ children, prevPRs, currPRs }) => {
+export default ({ children, prs }) => {
     return (
-        <PRsContext.Provider value={{prev: prevPRs, curr: currPRs}}>
+        <PRsContext.Provider value={prs}>
             {children}
         </PRsContext.Provider >
     );

--- a/src/js/hooks.jsx
+++ b/src/js/hooks.jsx
@@ -16,7 +16,11 @@ export const usePrevious = (value) => {
     return ref.current;
 };
 
-export const useApi = () => {
+export const useApi = (noUsers = false, noFilters = false) => {
+    if (noUsers) {
+        noFilters = true;
+    }
+
     const { getTokenSilently } = useAuth0();
     const {
         ready: filtersReady,
@@ -41,14 +45,24 @@ export const useApi = () => {
         prepareApi();
     });
 
-    const ready = filtersReady && apiReadyState;
-    const context = ready ? {
-        account: userContext.defaultAccount.id,
-        interval: dateInterval,
-        repositories: repositories,
-        contributors: contributors
-    } : {};
+    let context = {};
+    let ready = apiReadyState;
 
+    if (!noUsers) {
+        context = {...context, account: userContext.defaultAccount.id};
+    }
+
+    if (!noFilters) {
+        ready &= filtersReady;
+        context = {
+            ...context,
+            interval: dateInterval,
+            repositories: repositories,
+            contributors: contributors
+        };
+    }
+
+    context = ready ? context : {};
     return {
         api: apiState,
         ready,

--- a/src/js/pages/pipeline/Body.jsx
+++ b/src/js/pages/pipeline/Body.jsx
@@ -18,7 +18,7 @@ export default ({ children }) => {
     return (
         <>
           <MainMetrics />
-          <Thumbnails prs={prsContext.curr.prs} stages={stagesContext} activeCard={activeConf && activeConf.slug} />
+          <Thumbnails prs={prsContext.prs} stages={stagesContext} activeCard={activeConf && activeConf.slug} />
           {children}
         </>
     );

--- a/src/js/pages/pipeline/Filters.jsx
+++ b/src/js/pages/pipeline/Filters.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import { useAuth0 } from 'js/context/Auth0';
 import { useUserContext } from 'js/context/User';
@@ -21,7 +21,7 @@ const defaultDateInterval = { from: TWO_WEEKS_AGO, to: EOD };
 export default ({ children }) => {
     const { getTokenSilently } = useAuth0();
     const userContext = useUserContext();
-    const { reset: resetData } = useDataContext();
+    const { reset: resetData, setGlobal: setGlobalData } = useDataContext();
 
     const [readyState, setReadyState] = useState(false);
 
@@ -56,8 +56,10 @@ export default ({ children }) => {
     useMountEffect(() => {
         (async () => {
             const token = await getTokenSilently();
-            await updateReposFilter({...context, token, setters: reposSetters});
-            await updateContribsFilter({...context, token, setters: contribsSetters});
+            const initialRepos = await updateReposFilter({...context, token, setters: reposSetters});
+            setGlobalData('filter.repos', initialRepos);
+            const initialContribs = await updateContribsFilter({...context, token, setters: contribsSetters});
+            setGlobalData('filter.contribs', initialContribs);
             setReadyState(true);
         })();
     });
@@ -88,6 +90,7 @@ export default ({ children }) => {
         dateInterval = dateInterval || filteredDateIntervalState;
 
         setFilteredReposState(selectedRepos);
+        setGlobalData('filter.repos', selectedRepos);
 
         const token = await getTokenSilently();
         await updateContribsFilter({...context, token, dateInterval, repos: selectedRepos,
@@ -100,6 +103,9 @@ export default ({ children }) => {
         resetData();
         console.info('Contributors selection changed', selectedContribs);
         setFilteredContribsState(selectedContribs);
+        console.log("XXXX");
+        setGlobalData('filter.contribs', selectedContribs);
+        console.log("YYY");
         setReadyState(true);
     };
 

--- a/src/js/pages/pipeline/Overview.jsx
+++ b/src/js/pages/pipeline/Overview.jsx
@@ -13,7 +13,7 @@ import Tabs from 'js/components/layout/Tabs';
 import { dateTime, number } from 'js/services/format';
 
 export default () => {
-    const { curr: prsContext } = usePRsContext();
+    const prsContext = usePRsContext();
     const { leadtime: leadtimeContext, stages: stagesContext } = usePipelineContext();
 
     let slowerStage = 0;

--- a/src/js/pages/pipeline/PullRequests.jsx
+++ b/src/js/pages/pipeline/PullRequests.jsx
@@ -8,10 +8,7 @@ import { getPRs } from 'js/services/api';
 export default ({ children }) => {
     const { api, ready: apiReady, context: apiContext } = useApi();
     const { setGlobal: setGlobalData } = useDataContext();
-    const [prsState, setPrsState] = useState({
-        prev: { prs: [], users: {} },
-        curr: { prs: [], users: {} },
-    });
+    const [prsState, setPrsState] = useState({ prs: [], users: {} });
 
     useEffect(() => {
         if (!apiReady) {
@@ -34,7 +31,7 @@ export default ({ children }) => {
     }, [apiReady, api, apiContext.account, apiContext.interval, apiContext.repositories, apiContext.contributors, setGlobalData]);
 
     return (
-        <PRsContext prevPRs={prsState.prev} currPRs={prsState.curr}>
+        <PRsContext prs={prsState}>
             {children}
         </PRsContext>
     );

--- a/src/js/pages/pipeline/PullRequests.jsx
+++ b/src/js/pages/pipeline/PullRequests.jsx
@@ -2,11 +2,12 @@ import React, { useState, useEffect } from 'react';
 
 import PRsContext from 'js/context/PRs';
 import { useApi } from 'js/hooks';
-
+import { useDataContext } from 'js/context/Data';
 import { getPRs } from 'js/services/api';
 
 export default ({ children }) => {
     const { api, ready: apiReady, context: apiContext } = useApi();
+    const { setGlobal: setGlobalData } = useDataContext();
     const [prsState, setPrsState] = useState({
         prev: { prs: [], users: {} },
         curr: { prs: [], users: {} },
@@ -22,6 +23,7 @@ export default ({ children }) => {
             try {
                 const prs = await getPRs(api, apiContext.account, apiContext.interval,
                                          apiContext.repositories, apiContext.contributors);
+                setGlobalData('prs', prs);
                 setPrsState(prs);
             } catch (err) {
                 console.error('Could not get pull requests', err);
@@ -29,7 +31,7 @@ export default ({ children }) => {
         };
 
         getAndSetPRs();
-    }, [apiReady, api, apiContext.account, apiContext.interval, apiContext.repositories, apiContext.contributors]);
+    }, [apiReady, api, apiContext.account, apiContext.interval, apiContext.repositories, apiContext.contributors, setGlobalData]);
 
     return (
         <PRsContext prevPRs={prsState.prev} currPRs={prsState.curr}>

--- a/src/js/pages/pipeline/Stage.jsx
+++ b/src/js/pages/pipeline/Stage.jsx
@@ -14,7 +14,7 @@ import { usePRsContext } from 'js/context/PRs';
 
 export default () => {
     const { stages: stagesContext } = usePipelineContext();
-    const { curr: prsContext } = usePRsContext();
+    const prsContext = usePRsContext();
 
     const { name: stageSlug } = useParams();
     const activeConf = getStage(pipelineStagesConf, stageSlug);

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -16,29 +16,15 @@ import _ from 'lodash';
 import moment from 'moment';
 
 export const getPRs = async (api, accountId, dateInterval, repos, contributors) => {
-
-    const query = async (interval) => fetchFilteredPRs(api, accountId, interval, {
+    const currResult = await fetchFilteredPRs(api, accountId, dateInterval, {
         repositories: repos,
         developers: contributors,
         stages: ['wip', 'review', 'merge', 'release', 'done']
     });
 
-    const currInterval = dateInterval;
-    const prevInterval = getPreviousInterval(currInterval);
-
-    const currResult = await query(currInterval);
-    const prevResult = await query(prevInterval);
-
     return {
-        prev: {
-            prs: prevResult.data.map(processPR),
-            users: (prevResult.include && prevResult.include.users) || {},
-
-        },
-        curr: {
-            prs: currResult.data.map(processPR),
-            users: (currResult.include && currResult.include.users) || {},
-        }
+        prs: currResult.data.map(processPR),
+        users: (currResult.include && currResult.include.users) || {},
     };
 };
 

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -74,11 +74,12 @@ export const getRepos = (token, userAccount, from, to, repos) => {
 };
 
 export const getContributors = (token, userAccount, from, to, repos) => {
-  const api = buildApi(token);
-  const filter = new GenericFilterRequest(userAccount, from, to);
-  filter.in = repos;
-  return api.filterContributors({ body: filter })
-    .then(contribs => contribs.map(c => c.login));
+    const api = buildApi(token);
+    return fetchContributors(
+        api, userAccount,
+        {from: new Date(from), to: new Date(to)},
+        {repositories:repos}
+    ).then(contribs => contribs.map(c => c.login));
 };
 
 export const getMetrics = async (api, accountId, dateInterval, repos, contributors) => {
@@ -142,6 +143,17 @@ export const buildApi = token => {
 export const fetchApi = (token, apiCall, ...args) => {
   const api = buildApi(token);
   return apiCall(api, ...args);
+};
+
+export const fetchContributors = async (
+    api, accountID,
+    dateInterval,
+    filter = {repositories :[]}
+) => {
+    const filter_ = new GenericFilterRequest(
+        accountID, dateTime.ymd(dateInterval.from), dateTime.ymd(dateInterval.to));
+    filter_.in = filter.repositories;
+    return api.filterContributors({ body: filter_ });
 };
 
 export const fetchFilteredPRs = async (


### PR DESCRIPTION
This PR does the following:
- adds a proper way to handle global data through the `DataContext` provider and the `DataWidget`
- removes unnecessary query to previous filtered PRs
- changed a call to previous filtered PRs to previous filtered contribs

Locally for the overview page it reduced the number of requests from 17 to 15, and from 34s to 25s of loading: -26%.