### PR TITLE
Insights error handling

### DIFF
--- a/src/js/components/insights/Insights.jsx
+++ b/src/js/components/insights/Insights.jsx
@@ -40,10 +40,10 @@ export default () => {
             return;
         }
 
-        const emptyStage = !stageChartsState[stageSlug];
+        const stageValue = stageChartsState[stageSlug];
         const sameFilters = _.isEqual(latestApiContextUsedState, apiContext);
-        if (!emptyStage && sameFilters) {
-            console.log("Filters didn't change and state is not empty: not calling api");
+        if (!!stageValue && sameFilters) {
+            console.log("Filters didn't change and state is not empty: not calling api", stageValue);
             return;
         }
 
@@ -51,26 +51,24 @@ export default () => {
             setLoadingApiCallState(true);
             const prs = await getGlobalData('prs');
             console.log(`CALLING API for slug: ${stageSlug}`, apiContext);
+
+            const action = {
+                stageSlug,
+                reset: !sameFilters
+            };
+
             // TODO: Don't pass `prs` global data manually. Each insight chart should
             // be refactored to use the self-loader `js/components/DataWidget` component
             try {
-                const result = await getInsights(stageSlug, api, apiContext, prs);
-                const action = {
-                    stageSlug,
-                    result
-                };
-
-                if (!sameFilters) {
-                    action.reset = true;
-                };
-
-                console.log("Dispatching stage charts state change", action);
-                dispatchStageChartsState(action);
+                action.result = await getInsights(stageSlug, api, apiContext, prs);
             } catch(err) {
+                action.result = err;
                 console.log(err);
             } finally {
                 console.log("Updating latest filters");
                 setLatestApiContextUsedState(apiContext);
+                console.log("Dispatching stage charts state change", action);
+                dispatchStageChartsState(action);
                 setLoadingApiCallState(false);
             }
         };
@@ -79,6 +77,16 @@ export default () => {
     }, [stageSlug, api, apiContext, apiReady, latestApiContextUsedState, loadingApiCallState, stageChartsState, globalDataReady, getGlobalData]);
 
     const insights = stageChartsState[stageSlug];
+    if (insights instanceof Error) {
+        return (
+            <div className="row mt-5 mb-5">
+              <div className="col-12 mt-5 text-center">
+                <span>An error occurred when loading insights charts</span>
+              </div>
+            </div>
+        );
+    }
+
     const loading = !insights || !apiReady || loadingApiCallState;
     if (loading) {
         return (

--- a/src/js/components/insights/Insights.jsx
+++ b/src/js/components/insights/Insights.jsx
@@ -16,8 +16,7 @@ const stageChartsStateReducer = (state, action) => {
         return {[action.stageSlug]: action.result};
     }
 
-    state[action.stageSlug] = action.result;
-    return state;
+    return {...state, [action.stageSlug]: action.result};
 };
 
 export default () => {


### PR DESCRIPTION
Closes [ENG-615](https://athenianco.atlassian.net/browse/ENG-615).

This puts the loading of the insights section into an `error` state instead of looping and DDoS-ing the API. This shouldn't ever happen, but just in case I just put a simple copy. @warenlg up to you if wanna change it or provide a visual.

## Screenshot

<img width="1285" alt="Screenshot 2020-04-23 at 18 46 08" src="https://user-images.githubusercontent.com/5599208/80127063-16a83d80-8594-11ea-826d-9c7be808dbbd.png">
