### PR TITLE
Waiting regular users

### DIFF
--- a/src/js/pages/Waiting.jsx
+++ b/src/js/pages/Waiting.jsx
@@ -15,8 +15,11 @@ export default () => {
 
   const ghAppUrl = window.ENV.application.githubAppUri;
 
+  const isAdmin = userContext?.defaultAccount?.isAdmin;
+  const autoOpen = location.state?.ghAppAutoOpen;
+
   useEffect(() => {
-    if (!location.state?.ghAppAutoOpen) {
+    if (!isAdmin || !autoOpen) {
       return;
     }
 
@@ -25,10 +28,7 @@ export default () => {
     }, 5000);
 
     return () => clearTimeout(timer);
-  }, [ghAppOpenedState, location.state, ghAppUrl]);
-
-  const isAdmin = userContext?.defaultAccount?.isAdmin;
-  const autoOpen = location.state?.ghAppAutoOpen;
+  }, [ghAppOpenedState, isAdmin, autoOpen, ghAppUrl]);
 
   if (!isAdmin) {
     return (
@@ -61,7 +61,7 @@ export default () => {
           <>
             <div>
               Please, install and configure the Athenian GitHub application
-              at <GhAppLink url={ghAppUrl} onClick={() => setGhAppOpenedState(true)} />
+              at <GhAppLink url={ghAppUrl} onClick={() => { setGhAppOpeneErrorState(false); setGhAppOpenedState(true); }} />
             </div>
             <div className="mt-2">
               Once you install and configure the GitHub App, Athenian will start loading your data from GitHub. The loading process will take a while.

--- a/src/js/pages/Waiting.jsx
+++ b/src/js/pages/Waiting.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import Page from './templates/Page';
 
 import { useUserContext } from 'js/context/User';
 
 import logo from 'images/logos/logo-transparent.svg';
+
+export const FROM_REGISTRATION = 'registration';
 
 export default () => {
   const location = useLocation();
@@ -16,15 +18,15 @@ export default () => {
   const ghAppUrl = window.ENV.application.githubAppUri;
 
   const isAdmin = userContext?.defaultAccount?.isAdmin;
-  const autoOpen = location.state?.ghAppAutoOpen;
+  const autoOpen = location.state?.origin == FROM_REGISTRATION;
 
   useEffect(() => {
-    if (!isAdmin || !autoOpen) {
+    if (!isAdmin || !autoOpen || ghAppOpenedState) {
       return;
     }
 
     const timer = setTimeout(() => {
-      !ghAppOpenedState && openGhApp(ghAppUrl, () => setGhAppOpenedState(true), () => setGhAppOpeneErrorState(true))
+      openGhApp(ghAppUrl, () => setGhAppOpenedState(true), () => setGhAppOpeneErrorState(true))
     }, 5000);
 
     return () => clearTimeout(timer);
@@ -34,7 +36,7 @@ export default () => {
     return (
       <Slide
         title="Welcome to Athenian"
-        text="Please wait while we are fetching your data…"
+        text={<Link to="/stage/overview" className="btn btn-large btn-orange">Get the insights</Link>}
       >
         <Welcome />
       </Slide>
@@ -45,7 +47,7 @@ export default () => {
     return (
       <Slide
         title="Welcome to Athenian"
-        text="Please wait while we are fetching your data…"
+        text={<Link to="/stage/overview" className="btn btn-large btn-orange">Get the insights</Link>}
         footer={<>To install and configure the GitHub application, open <GhAppLink url={ghAppUrl} /></>}
       >
         <Welcome />

--- a/src/js/pages/auth/Callback.jsx
+++ b/src/js/pages/auth/Callback.jsx
@@ -3,6 +3,7 @@ import { useLocation, Redirect } from 'react-router-dom';
 
 import { useAuth0 } from 'js/context/Auth0';
 import Simple from 'js/pages/templates/Simple';
+import { FROM_REGISTRATION } from 'js/pages/Waiting';
 
 import { buildApi } from 'js/services/api';
 import InvitationLink from 'js/services/api/openapi-client/model/InvitationLink';
@@ -34,8 +35,8 @@ export default () => {
           invitationAcceptRequest.current = true;
           const check = await acceptInvite(token, inviteLink);
           setRedirectTo({
-            pathname: '/waiting',
-            state: { ghAppAutoOpen: check.type === 'admin' },
+            pathname: check.type === 'admin' ? '/waiting' : '/stage/overview',
+            state: { origin: FROM_REGISTRATION },
           });
         } catch (err) {
           setErrorMessage(err.message);

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -45,7 +45,7 @@ export const getUserWithAccountRepos = async token => {
       reposets = await api.listReposets(Number(accountID));
     } catch (err) {
       console.error(`Could not list reposets from account #${accountID}. Err#${err.body.status} ${err.body.type}. ${err.body.detail}`);
-      return { id: Number(accountID), reposets: [] };
+      return { id: Number(accountID), isAdmin, reposets: [] };
     }
 
     const reposetsContent = await Promise.all(reposets.map(async reposet => ({


### PR DESCRIPTION
solves [[ENG-683]] and [[ENG-682]]

- 13ad58a Ensure that regular users go to Overview after accepting regular invitations
- 49c0584 Handle possible errors …
  - When the GH App page can not be opened, and the user clicks in the link to open it,
the error message will disappear.
  - GH App page will only be opened if the logged user is admin.

Also:
- 7723f8e Fix. Mark as an admin a user owning an account even when it does not have any reposet

[ENG-683]: https://athenianco.atlassian.net/browse/ENG-683
[ENG-682]: https://athenianco.atlassian.net/browse/ENG-682