### PR TITLE
Fix PR labeling when no stage has been completed

### DIFF
--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -270,6 +270,10 @@ export const prLabel = stage => pr => {
 
         return PR_LABELS.RELEASE_PENDING;
     default:
+        if (isStageHappening(PR_STAGE.DONE)) {
+            return PR_LABELS.RELEASE_COMPLETED;
+        }
+
         if (pr.completedStages.length === 0) {
             if (isStageHappening(PR_STAGE.RELEASE)) {
                 return PR_LABELS.RELEASE_PENDING;


### PR DESCRIPTION
Fix https://athenianco.atlassian.net/browse/ENG-709
For the same date interval (March 1st to March 31st) before,
![before](https://user-images.githubusercontent.com/24694845/80403519-0065ee80-88c0-11ea-9d3c-04d317ff1d0a.png)
After,
![Screenshot from 2020-04-27 19-42-40](https://user-images.githubusercontent.com/24694845/80403534-06f46600-88c0-11ea-9842-9233d8916f0b.png)


Signed-off-by: Waren Long <waren@athenian.co>