### PR TITLE
Fix datefilter

### DIFF
--- a/src/js/components/ui/filters/DateInterval.jsx
+++ b/src/js/components/ui/filters/DateInterval.jsx
@@ -106,7 +106,7 @@ export default ({
                 keepOpenOnDateSelect={true}
                 reopenPickerOnClearDates={false}
                 showClearDates={true}
-                initialVisibleMonth={() => moment().subtract(1, "M")}
+                initialVisibleMonth={() => moment(dateIntervalState.endDate).subtract(1, 'month')}
                 renderCalendarInfo={() => (
                     <CustomInfoPanel
                         onCancel={cancel}


### PR DESCRIPTION
caused by https://github.com/athenianco/athenian-webapp/pull/277
depends on https://github.com/athenianco/athenian-webapp/pull/285

Only this commit : c324bc8f880730acce2ce3ce793d626204e535a2

Open the calendar pointing to the active filter instead of today.
https://www.loom.com/share/26a51d9fb33c45419a4d0dc8e9cad0cf