### PR TITLE
Fix the height of the horizontal bar charts

### DIFF
--- a/src/js/components/insights/charts/library/HorizontalBarChart.jsx
+++ b/src/js/components/insights/charts/library/HorizontalBarChart.jsx
@@ -57,7 +57,7 @@ const HorizontalBarChart = ({ title, data, extra }) => {
     const ChartTooltip = extra?.tooltip?.template || Tooltip;
 
     return (
-        <FlexibleWidthXYPlot height={data.length * 40 * Object.keys(extra.series).length} margin={{ left: 50 }} yType="ordinal">
+        <FlexibleWidthXYPlot height={data.length * 40} margin={{ left: 50 }} yType="ordinal">
           <DiscreteColorLegend className="chart-legend" items={legend} orientation="horizontal" />
           <VerticalGridLines />
           <XAxis />
@@ -72,7 +72,7 @@ const HorizontalBarChart = ({ title, data, extra }) => {
                                      data={s.reverse()}
                                      color={extra.series[k].color}
                                      key={k}
-                                     barWidth={extra.barWidth || 0.5}
+                                     barWidth={0.6}
                                      onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
                                      onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}
                                    />).value()}

--- a/src/js/components/insights/stages/review/reviewActivity.jsx
+++ b/src/js/components/insights/stages/review/reviewActivity.jsx
@@ -223,7 +223,6 @@ const reviewActivity = {
                                     imageMask: 'circle'
                                 },
                                 axisKeys: computed.secondBox.axisKeys,
-                                barWidth: 0.6,
                                 series: {
                                     prsCommentsPerc: {
                                         name: '% Reviews Comments',


### PR DESCRIPTION
https://athenianco.atlassian.net/browse/ENG-733

Before,
![Screenshot from 2020-04-29 22-13-27](https://user-images.githubusercontent.com/24694845/80642843-6ccf2200-8a67-11ea-9366-d8a70fe2fd56.png)
After,
![hbar_chart](https://user-images.githubusercontent.com/24694845/80642857-7193d600-8a67-11ea-950a-762024b83d5e.png)

In particular, with this PR, the chart has the same height as the **Pull Requests Authors** chart in the WIP section, for a given number of users displayed in the y-axis

Signed-off-by: Waren Long <waren@athenian.co>