### PR TITLE
Add the Review Submitted PR label

### DIFF
--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -254,6 +254,8 @@ export const prLabel = stage => pr => {
             } else {
                 return PR_LABELS.REVIEW_IGNORED;
             }
+        } else if (pr.properties.includes(PR_EVENT.REVIEW)) {
+            return PR_LABELS.REVIEW_SUBMITTED;
         }
 
         return PR_LABELS.REVIEW_PENDING;
@@ -278,6 +280,8 @@ export const prLabel = stage => pr => {
             }  else if (isStageHappening(PR_STAGE.REVIEW)) {
                 if (pr.properties.includes(PR_EVENT.REJECTION)) {
                     return PR_LABELS.REVIEW_REJECTED;
+                } else if (pr.properties.includes(PR_EVENT.REVIEW)) {
+                    return PR_LABELS.REVIEW_SUBMITTED;
                 } else {
                     return PR_LABELS.REVIEW_PENDING;
                 }
@@ -294,6 +298,8 @@ export const prLabel = stage => pr => {
             return PR_LABELS.MERGE_PENDING;
         } else if (pr.properties.includes(PR_EVENT.REJECTION)) {
             return PR_LABELS.REVIEW_REJECTED;
+        } else if (pr.properties.includes(PR_EVENT.REVIEW)) {
+            return PR_LABELS.REVIEW_SUBMITTED;
         } else if (hasCompletedStage(PR_STAGE.WIP)) {
             return PR_LABELS.REVIEW_PENDING;
         }

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -19,6 +19,7 @@ $color-light-orange: #FFA008;
 $color-yellow: #FFC508;
 $color-green: #2FCC71;
 $color-turquoise: #24C7CC;
+$color-wheat: #e9b658;
 
 $color-primary: $color-light-orange;
 $color-secondary: #8889A1;

--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -75,10 +75,14 @@
             color: $color-brown;
         }
 
-        &.label-review-pending,
-        &.label-review-submitted {
+        &.label-review-pending {
             border-color: $color-review;
             color: $color-review;
+        }
+
+        &.label-review-submitted {
+            border-color: $color-wheat;
+            color: $color-wheat;
         }
 
         &.label-review-rejected {


### PR DESCRIPTION
https://athenianco.atlassian.net/browse/ENG-731

Many of the QR PRs are reviewed but still labeled as Waiting for Review similarly as for https://github.com/athenianco/athenian-webapp/pull/109 because we don't cover the case of a commented review (neither approval nor changes requested).
From now, they will be labeled as, **Review Submitted**.
![Screenshot from 2020-04-30 11-04-16](https://user-images.githubusercontent.com/24694845/80693717-b8b7b080-8ad3-11ea-9b74-17cdce18c251.png)

Signed-off-by: Waren Long <waren@athenian.co>