### PR TITLE
Enable /bearer on prod

### DIFF
--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -92,7 +92,7 @@ export default () => {
             <Settings />
           </ContextRoute>
 
-          {devmode && <Route path='/bearer'><Development.Bearer /></Route>}
+          <Route path='/bearer'><Development.Bearer /></Route>
 
           <ContextRoute context={UserContext} path='/waiting'>
             <Waiting />

--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -39,11 +39,6 @@ export default () => {
         analytics.page();
     }, [location]);
 
-    const devmode = (
-        process.env.NODE_ENV === 'development' ||
-            ['development', 'staging'].includes(window.ENV.environment)
-    );
-
     return (
         <Switch>
 


### PR DESCRIPTION
@warenlg, @eiso and I suffer every day: we use the god mode on prod heavily and often change accounts. It is VERY annoying for us to go to the developer tools every time we need an updated Bearer token. The previous assumption that we don't need `/bearer` on prod is completely destroyed, just as I expected.

Please merge this ASAP.