### PR TITLE
User no account not allowed

### DIFF
--- a/src/js/Routes.jsx
+++ b/src/js/Routes.jsx
@@ -17,6 +17,7 @@ import Pipeline from 'js/pages/Pipeline';
 import Stage from 'js/pages/pipeline/Stage';
 import Overview from 'js/pages/pipeline/Overview';
 import Login from 'js/pages/auth/Login';
+import SignUp from 'js/pages/auth/SignUp';
 import Logout from 'js/pages/auth/Logout';
 import Development from 'js/components/development';
 import Callback from 'js/pages/auth/Callback';
@@ -70,7 +71,7 @@ export default () => {
           <Route path='/i/:code(\w{8})'>
             <Redirect to={
                 {
-                    pathname: '/login',
+                    pathname: '/signup',
                     state: { inviteLink: window.location.href }
                 }
             } />
@@ -78,6 +79,10 @@ export default () => {
 
           <Route path='/callback'>
             <Callback />
+          </Route>
+
+          <Route path='/signup'>
+            <SignUp />
           </Route>
 
           <Route path='/login'>

--- a/src/js/components/layout/Navbar.jsx
+++ b/src/js/components/layout/Navbar.jsx
@@ -8,18 +8,18 @@ import defaultImage from 'images/default-user-image.png';
 
 import InvitationCreator from 'js/smart-components/InvitationCreator';
 
-export default ({ user }) => (
+export default ({ user, invitationDisabled }) => (
   <div className="navbar navbar-expand-sm navbar-light bg-white topbar static-top border-bottom">
     <div className="container d-flex justify-content-between align-items-center">
       <Link to="/">
         <img src={logo} className="app-logo" alt="athenian" />
       </Link>
-      <User user={user} />
+      <User user={user} invitationDisabled={invitationDisabled}/>
     </div>
   </div>
 );
 
-const User = ({ user }) => {
+const User = ({ user, invitationDisabled }) => {
 
   return user ? (
     <ul className="navbar-nav ml-auto pr-0">
@@ -35,7 +35,7 @@ const User = ({ user }) => {
               <p className="mb-0 text-truncate font-weight-light text-s">{user.email}</p>
             </div>
           </header>
-          <InvitationCreator user={user} className="menuItem py-3" />
+          {!invitationDisabled && <InvitationCreator user={user} className="menuItem py-3" />}
           <footer className="menuItem d-flex flex-row align-items-center justify-content-end bg-light py-2 text-xs border-top">
             <Link to="/logout" className="text-s text-secondary">Logout</Link>
           </footer>

--- a/src/js/context/User.jsx
+++ b/src/js/context/User.jsx
@@ -37,7 +37,7 @@ export default ({ children }) => {
     }
 
     return (
-        <UserContext.Provider value={userState}>
+        <UserContext.Provider value={{user: userState, isAuthenticated}}>
           {
               userState && !userState.defaultAccount ? (
                   <Simple>

--- a/src/js/context/User.jsx
+++ b/src/js/context/User.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useAuth0 } from 'js/context/Auth0';
 
-import Simple from 'js/pages/templates/Simple';
-
 import { getUserWithAccountRepos } from 'js/services/api';
 import { analytics } from 'js/analytics';
 
@@ -12,10 +10,16 @@ export const useUserContext = () => useContext(UserContext);
 
 export default ({ children }) => {
     const { logout, loading, isAuthenticated, getTokenSilently } = useAuth0();
+    const [userStateLoading, setUserStateLoading] = useState(true);
     const [userState, setUserState] = useState(null);
 
     useEffect(() => {
+        if (loading) {
+            return;
+        }
+
         if (!isAuthenticated) {
+            setUserStateLoading(false);
             return;
         };
 
@@ -25,32 +29,21 @@ export default ({ children }) => {
                 const userWithRepos = await getUserWithAccountRepos(token);
                 analytics.identify(userWithRepos);
                 setUserState(userWithRepos);
-
             } catch(err) {
                 console.error('Could not get user with repos', err);
+            } finally {
+                setUserStateLoading(false);
             }
         })();
-    }, [isAuthenticated, getTokenSilently]);
+    }, [loading, isAuthenticated, getTokenSilently]);
 
-    if (loading) {
+    if (userStateLoading) {
         return null;
     }
 
     return (
-        <UserContext.Provider value={{user: userState, isAuthenticated}}>
-          {
-              userState && !userState.defaultAccount ? (
-                  <Simple>
-                    <p>Your user was not invited to any account. You should accept an invitation first.</p>
-                    <button onClick={() => logout({ returnTo: window.ENV.auth.logoutRedirectUri })}>logout</button>
-                  </Simple>
-              ) : (
-                  <>
-                    {children}
-                  </>
-
-              )
-          }
+        <UserContext.Provider value={{user: userState, isAuthenticated, logout}}>
+          {children}
         </UserContext.Provider >
     );
 };

--- a/src/js/hooks.jsx
+++ b/src/js/hooks.jsx
@@ -16,56 +16,84 @@ export const usePrevious = (value) => {
     return ref.current;
 };
 
-export const useApi = (noUsers = false, noFilters = false) => {
-    if (noUsers) {
-        noFilters = true;
-    }
+const useApiOnly = () => {
+    const { loading, isAuthenticated, loginWithRedirect, logout, getTokenSilently } = useAuth0();
+    const [apiState, setApiState] = useState(null);
 
-    const { getTokenSilently } = useAuth0();
+    useEffect(() => {
+        if (!isAuthenticated) {
+            return;
+        }
+
+        const prepareApi = async () => {
+            const token = await getTokenSilently();
+            const api = buildApi(token);
+
+            setApiState(api);
+        };
+
+        prepareApi();
+    }, [isAuthenticated, getTokenSilently]);
+
+    return {
+        api: apiState,
+        ready: !!apiState,
+        auth: {
+            loading,
+            isAuthenticated,
+            loginWithRedirect,
+            logout
+        },
+        context: {}
+    };
+};
+
+const useApiWithUser = () => {
+    const {api, auth, ready: apiReady} = useApiOnly();
+    const userContext = useUserContext();
+
+    const context = apiReady ? {account: userContext.defaultAccount.id} : {};
+    return {
+        api,
+        ready: apiReady,
+        auth,
+        context
+    };
+};
+
+const useApiWithFilters = () => {
+    const {api, auth, ready: apiReady, context: apiContext} = useApiWithUser();
     const {
         ready: filtersReady,
         dateInterval,
         repositories,
         contributors
     } = useFiltersContext();
-    const userContext = useUserContext();
 
-    const [apiState, setApiState] = useState(null);
-    const [apiReadyState, setApiStateReady] = useState(false);
+    const ready = apiReady && filtersReady;
+    const context = {
+        ...apiContext,
+        interval: dateInterval,
+        repositories: repositories,
+        contributors: contributors
+    };
 
-    useMountEffect(() => {
-        const prepareApi = async () => {
-            const token = await getTokenSilently();
-            const api = buildApi(token);
-
-            setApiState(api);
-            setApiStateReady(true);
-        };
-
-        prepareApi();
-    });
-
-    let context = {};
-    let ready = apiReadyState;
-
-    if (!noUsers) {
-        context = {...context, account: userContext.defaultAccount.id};
-    }
-
-    if (!noFilters) {
-        ready &= filtersReady;
-        context = {
-            ...context,
-            interval: dateInterval,
-            repositories: repositories,
-            contributors: contributors
-        };
-    }
-
-    context = ready ? context : {};
     return {
-        api: apiState,
+        api: api,
         ready,
+        auth,
         context
     };
+};
+
+export const useApi = (withUser = true, withFilters = true) => getApiHook(withUser, withFilters)();
+
+const getApiHook = (withUser = true, withFilters = true) => {
+    if (withFilters) {
+        return useApiWithFilters;
+    } else if (withUser) {
+        return useApiWithUser;
+    } else {
+        return useApiOnly;
+    }
 };

--- a/src/js/hooks.jsx
+++ b/src/js/hooks.jsx
@@ -50,9 +50,9 @@ const useApiOnly = () => {
 
 const useApiWithUser = () => {
     const {api, auth, ready: apiReady} = useApiOnly();
-    const userContext = useUserContext();
+    const { user } = useUserContext();
 
-    const context = apiReady ? {account: userContext.defaultAccount.id} : {};
+    const context = apiReady ? {account: user.defaultAccount.id} : {};
     return {
         api,
         ready: apiReady,

--- a/src/js/pages/Settings.jsx
+++ b/src/js/pages/Settings.jsx
@@ -12,11 +12,11 @@ import { useUserContext } from 'js/context/User';
 import { Link } from 'react-router-dom';
 
 export default () => {
-  const userContext = useUserContext();
+  const { user } = useUserContext();
 
-  if (!userContext) return null;
+  if (!user) return null;
 
-  const orgName = _(userContext.defaultReposet.repos)
+  const orgName = _(user.defaultReposet.repos)
     .map(r => r.split('/')[1])
     .uniq()
     .value();
@@ -32,9 +32,9 @@ export default () => {
         <div className="col-2">
           <div className="card mb-5">
             <div className="card-header text-center bg-white">
-              <img className="rounded-circle mt-2 mb-4" src={userContext.picture || defaultImage} alt="" width="100" />
-              <h3 className="text-dark text-truncate h5">{userContext.name}</h3>
-              <p className="text-secondary text-truncate font-weight-light">{userContext.email}</p>
+              <img className="rounded-circle mt-2 mb-4" src={user.picture || defaultImage} alt="" width="100" />
+              <h3 className="text-dark text-truncate h5">{user.name}</h3>
+              <p className="text-secondary text-truncate font-weight-light">{user.email}</p>
             </div>
             <div className="card-body p-0">
               <div className="list-group list-group-flush">
@@ -70,10 +70,10 @@ export default () => {
               <p className="text-dark mt-2 mb-3">User Information</p>
               <div className="card bg-light mb-5">
                 <div className="card-body d-flex align-items-center">
-                  <img className="rounded-circle mr-3" src={userContext.picture || defaultImage} alt="" width="80" />
+                  <img className="rounded-circle mr-3" src={user.picture || defaultImage} alt="" width="80" />
                   <div>
-                    <h3 className="text-dark text-truncate h5">{userContext.name} <FontAwesomeIcon icon={faGithub} /></h3>
-                    <p className="text-secondary text-truncate font-weight-light mb-0">{userContext.email}</p>
+                    <h3 className="text-dark text-truncate h5">{user.name} <FontAwesomeIcon icon={faGithub} /></h3>
+                    <p className="text-secondary text-truncate font-weight-light mb-0">{user.email}</p>
                   </div>
                 </div>
               </div>

--- a/src/js/pages/Waiting.jsx
+++ b/src/js/pages/Waiting.jsx
@@ -11,13 +11,13 @@ export const FROM_REGISTRATION = 'registration';
 
 export default () => {
   const location = useLocation();
-  const userContext = useUserContext();
+  const { user } = useUserContext();
   const [ghAppOpenedState, setGhAppOpenedState] = useState(false);
   const [ghAppOpenErrorState, setGhAppOpeneErrorState] = useState(false);
 
   const ghAppUrl = window.ENV.application.githubAppUri;
 
-  const isAdmin = userContext?.defaultAccount?.isAdmin;
+  const isAdmin = user?.defaultAccount?.isAdmin;
   const autoOpen = location.state?.origin === FROM_REGISTRATION;
 
   useEffect(() => {

--- a/src/js/pages/Waiting.jsx
+++ b/src/js/pages/Waiting.jsx
@@ -122,7 +122,7 @@ const GhAppLink = ({ url, ...rest }) => (
 
 const Slide = ({ title, text, footer, children }) => {
   return (
-    <Page>
+      <Page invitationDisabled={true}>
       <div className="row h-100">
         <div className="col-12 my-auto">
           <div className="mt-3 mb-5 text-center">

--- a/src/js/pages/auth/Callback.jsx
+++ b/src/js/pages/auth/Callback.jsx
@@ -1,62 +1,51 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useLocation, Redirect } from 'react-router-dom';
 
-import { useAuth0 } from 'js/context/Auth0';
 import Simple from 'js/pages/templates/Simple';
 import { FROM_REGISTRATION } from 'js/pages/Waiting';
 
-import { buildApi } from 'js/services/api';
+import { useApi } from 'js/hooks';
 import InvitationLink from 'js/services/api/openapi-client/model/InvitationLink';
 
 export default () => {
+    const {api, ready: apiReady, auth} = useApi(false, false);
+
     const invitationAcceptRequest = useRef(false);
-    const { loading, isAuthenticated, getTokenSilently, logout } = useAuth0();
     const [redirectTo, setRedirectTo] = useState(null);
     const [errorMessage, setErrorMessage] = useState('');
     const query = new URLSearchParams(useLocation().search);
 
     useEffect(() => {
-        if (loading || !isAuthenticated || invitationAcceptRequest.current) {
+        if (!apiReady || invitationAcceptRequest.current) {
             return;
         };
 
-        getTokenSilently()
-            .then(async token => {
-                const inviteLink = query.get('inviteLink');
+        invitationAcceptRequest.current = true;
 
-                if (!inviteLink) {
-                    setRedirectTo({
-                        pathname: query.get('targetUrl') || '/',
-                    });
-                    return;
-                }
+        (async () => {
+            const inviteLink = query.get('inviteLink');
 
-                try {
-                    invitationAcceptRequest.current = true;
-                    const check = await acceptInvite(token, inviteLink);
-                    setRedirectTo({
-                        pathname: check.type === 'admin' ? '/waiting' : '/stage/overview',
-                        state: { origin: FROM_REGISTRATION },
-                    });
-                } catch (err) {
-                    setErrorMessage(err.message);
+            if (!inviteLink) {
+                setRedirectTo({
+                    pathname: query.get('targetUrl') || '/',
+                });
+                return;
+            }
 
-                    // TODO (dpordomingo):
-                    // This is needed because if the invitation fails, the user should not be logged in.
-                    // Also, the logout is delayed because Auth0 redirects to the 'logoutRedirectUri'
-                    // inmediately, and then the user would not be able to see the error message.
-                    // Workaround: store the error, let Auth0 to redirect, and then show the stored message.
-                    window.setTimeout(() => logout({ returnTo: window.ENV.auth.logoutRedirectUri }), 3000);
-                    return;
-                }
-            });
-    }, [loading, isAuthenticated, getTokenSilently, logout, query]);
+            try {
+                const check = await acceptInvite(api, inviteLink);
+                setRedirectTo({
+                    pathname: check.type === 'admin' ? '/waiting' : '/stage/overview',
+                    state: { origin: FROM_REGISTRATION },
+                });
+            } catch (err) {
+                setErrorMessage(err.message);
+                window.setTimeout(() => setRedirectTo({pathname: '/'}), 3000);
+            }
+        })();
+    }, [apiReady, api, auth.logout, query, auth]);
 
-    if (errorMessage) {
-        return <Simple>{errorMessage}</Simple>;
-    }
-
-    if (loading) {
+    if (auth.loading) {
         return <Simple>Loading...</Simple>;
     }
 
@@ -64,15 +53,27 @@ export default () => {
         return <Redirect to={redirectTo} />;
     }
 
+    if (errorMessage) {
+        return (
+            <Simple linkToHome={false}>
+              <div>
+                <div>An error occurred while accepting the invitation:
+                  <span className="mt-3" style={{display: "block", fontStyle: "italic"}}>{errorMessage}</span>
+                </div>
+                <div className="mt-5">You'll be redirected to the home page.</div>
+              </div>
+            </Simple>
+        );
+    }
+
     return (
         <Simple>
-          {isAuthenticated ? 'Authenticated' : 'Not authenticated'}
+          {auth.isAuthenticated ? 'Authenticated' : 'Not authenticated'}
         </Simple>
     );
 };
 
-const acceptInvite = async (token, inviteLink) => {
-    const api = buildApi(token);
+const acceptInvite = async (api, inviteLink) => {
     const body = new InvitationLink(inviteLink);
 
     let check;

--- a/src/js/pages/auth/Callback.jsx
+++ b/src/js/pages/auth/Callback.jsx
@@ -9,89 +9,89 @@ import { buildApi } from 'js/services/api';
 import InvitationLink from 'js/services/api/openapi-client/model/InvitationLink';
 
 export default () => {
-  const invitationAcceptRequest = useRef(false);
-  const { loading, isAuthenticated, getTokenSilently, logout } = useAuth0();
-  const [redirectTo, setRedirectTo] = useState(null);
-  const [errorMessage, setErrorMessage] = useState('');
-  const query = new URLSearchParams(useLocation().search);
+    const invitationAcceptRequest = useRef(false);
+    const { loading, isAuthenticated, getTokenSilently, logout } = useAuth0();
+    const [redirectTo, setRedirectTo] = useState(null);
+    const [errorMessage, setErrorMessage] = useState('');
+    const query = new URLSearchParams(useLocation().search);
 
-  useEffect(() => {
-    if (loading || !isAuthenticated || invitationAcceptRequest.current) {
-      return;
-    };
+    useEffect(() => {
+        if (loading || !isAuthenticated || invitationAcceptRequest.current) {
+            return;
+        };
 
-    getTokenSilently()
-      .then(async token => {
-        const inviteLink = query.get('inviteLink');
+        getTokenSilently()
+            .then(async token => {
+                const inviteLink = query.get('inviteLink');
 
-        if (!inviteLink) {
-          setRedirectTo({
-            pathname: query.get('targetUrl') || '/',
-          });
-          return;
-        }
+                if (!inviteLink) {
+                    setRedirectTo({
+                        pathname: query.get('targetUrl') || '/',
+                    });
+                    return;
+                }
 
-        try {
-          invitationAcceptRequest.current = true;
-          const check = await acceptInvite(token, inviteLink);
-          setRedirectTo({
-            pathname: check.type === 'admin' ? '/waiting' : '/stage/overview',
-            state: { origin: FROM_REGISTRATION },
-          });
-        } catch (err) {
-          setErrorMessage(err.message);
+                try {
+                    invitationAcceptRequest.current = true;
+                    const check = await acceptInvite(token, inviteLink);
+                    setRedirectTo({
+                        pathname: check.type === 'admin' ? '/waiting' : '/stage/overview',
+                        state: { origin: FROM_REGISTRATION },
+                    });
+                } catch (err) {
+                    setErrorMessage(err.message);
 
-          // TODO (dpordomingo):
-          // This is needed because if the invitation fails, the user should not be logged in.
-          // Also, the logout is delayed because Auth0 redirects to the 'logoutRedirectUri'
-          // inmediately, and then the user would not be able to see the error message.
-          // Workaround: store the error, let Auth0 to redirect, and then show the stored message.
-          window.setTimeout(() => logout({ returnTo: window.ENV.auth.logoutRedirectUri }), 3000);
-          return;
-        }
-      });
-  }, [loading, isAuthenticated, getTokenSilently, logout, query]);
+                    // TODO (dpordomingo):
+                    // This is needed because if the invitation fails, the user should not be logged in.
+                    // Also, the logout is delayed because Auth0 redirects to the 'logoutRedirectUri'
+                    // inmediately, and then the user would not be able to see the error message.
+                    // Workaround: store the error, let Auth0 to redirect, and then show the stored message.
+                    window.setTimeout(() => logout({ returnTo: window.ENV.auth.logoutRedirectUri }), 3000);
+                    return;
+                }
+            });
+    }, [loading, isAuthenticated, getTokenSilently, logout, query]);
 
-  if (errorMessage) {
-    return <Simple>{errorMessage}</Simple>;
-  }
+    if (errorMessage) {
+        return <Simple>{errorMessage}</Simple>;
+    }
 
-  if (loading) {
-    return <Simple>Loading...</Simple>;
-  }
+    if (loading) {
+        return <Simple>Loading...</Simple>;
+    }
 
-  if (redirectTo?.pathname) {
-    return <Redirect to={redirectTo} />;
-  }
+    if (redirectTo?.pathname) {
+        return <Redirect to={redirectTo} />;
+    }
 
-  return (
-    <Simple>
-      {isAuthenticated ? 'Authenticated' : 'Not authenticated'}
-    </Simple>
-  );
+    return (
+        <Simple>
+          {isAuthenticated ? 'Authenticated' : 'Not authenticated'}
+        </Simple>
+    );
 };
 
 const acceptInvite = async (token, inviteLink) => {
-  const api = buildApi(token);
-  const body = new InvitationLink(inviteLink);
+    const api = buildApi(token);
+    const body = new InvitationLink(inviteLink);
 
-  let check;
-  try {
-    check = await api.checkInvitation(body);
-  } catch (err) {
-    throw new Error(`Error reading the invitation ${err.error.message}`);
-  }
+    let check;
+    try {
+        check = await api.checkInvitation(body);
+    } catch (err) {
+        throw new Error(`Error reading the invitation ${err.error.message}`);
+    }
 
-  if (!check.valid || !check.active) {
-    const cause = !check.valid ? 'valid' : 'active';
-    throw new Error(`Invitation is not ${cause}`);
-  }
+    if (!check.valid || !check.active) {
+        const cause = !check.valid ? 'valid' : 'active';
+        throw new Error(`Invitation is not ${cause}`);
+    }
 
-  try {
-    await api.acceptInvitation(body);
-  } catch (err) {
-    throw new Error(`Could not accept the invitation. Err#${err.body.status} ${err.body.type}. ${err.body.detail}`);
-  }
+    try {
+        await api.acceptInvitation(body);
+    } catch (err) {
+        throw new Error(`Could not accept the invitation. Err#${err.body.status} ${err.body.type}. ${err.body.detail}`);
+    }
 
-  return check;
+    return check;
 };

--- a/src/js/pages/auth/Login.jsx
+++ b/src/js/pages/auth/Login.jsx
@@ -1,57 +1,43 @@
 import React from 'react';
-import { Link, useLocation, Redirect } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 
 import { useAuth0 } from 'js/context/Auth0';
 import Simple from 'js/pages/templates/Simple';
 
 export default () => {
-  const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
-  const location = useLocation();
-  const inviteLink = location.state?.inviteLink;
+    const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
 
-  if (loading) {
-    return <Simple>
-        <div className="my-5">
-            <p className="text-secondary">Loading...</p>
-        </div>
-    </Simple>;
-  }
+    if (loading) {
+        return (
+            <Simple>
+              <div className="my-5">
+                <p className="text-secondary">Loading...</p>
+              </div>
+            </Simple>
+        );
+    }
 
-  if (isAuthenticated) {
-    return inviteLink ?
-      (
+    if (isAuthenticated) {
+        return <Redirect to={{ pathname: '/' }} />;
+    }
+
+    return (
         <Simple>
-            <div className="my-5">
-                <p className="text-secondary">You must <Link to="/logout">logout</Link> first, and then open the invitation link.</p>
-            </div>
-        </Simple>
-      ) : (
-        <Redirect to={{ pathname: '/' }} />
-      );
-  }
-
-  return (
-    <Simple>
-      {inviteLink && (
           <div className="my-5">
-            <p className="text-secondary">Login to accept invitation {inviteLink}</p>
+            <h2 className="text-dark h4 mb-2">Welcome!</h2>
+            <p className="text-secondary">Click to access your Athenian account</p>
           </div>
-      )}
-      <div className="my-5">
-          <h2 className="text-dark h4 mb-2">Welcome!</h2>
-          <p className="text-secondary">Click to access your Athenian account</p>
-      </div>
 
-      <button
-        type="button"
-        className="btn btn-xlarge btn-orange"
-        onClick={() => loginWithRedirect({ appState: { inviteLink } })}
-      >
-        Login
-      </button>
-      <div className="my-5">
-        <a className="text-dark-orange" href="https://www.athenian.co">I don’t have an account</a>
-      </div>
-    </Simple>
-  );
+          <button
+            type="button"
+            className="btn btn-xlarge btn-orange"
+            onClick={() => loginWithRedirect()}
+          >
+            Login
+          </button>
+          <div className="my-5">
+            <a className="text-dark-orange" href="https://www.athenian.co">I don’t have an account</a>
+          </div>
+        </Simple>
+    );
 };

--- a/src/js/pages/auth/SignUp.jsx
+++ b/src/js/pages/auth/SignUp.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+import { useAuth0 } from 'js/context/Auth0';
+import Simple from 'js/pages/templates/Simple';
+
+export default () => {
+    const { loading, isAuthenticated, loginWithRedirect } = useAuth0();
+    const location = useLocation();
+    const inviteLink = location.state?.inviteLink;
+
+    if (!inviteLink) {
+        return <NoInvitation/>;
+    }
+
+    if (loading) {
+        return (
+            <Simple>
+              <div className="my-5">
+                <p className="text-secondary">Loading...</p>
+              </div>
+            </Simple>
+        );
+    }
+
+    if (isAuthenticated) {
+        return (
+                <Simple>
+                  <div className="my-5">
+                    <p className="text-secondary">You must <Link to="/logout">logout</Link> first, and then open the invitation link.</p>
+                  </div>
+                </Simple>
+        );
+    }
+
+    return (
+        <Simple>
+          <div className="my-5">
+            <p className="text-secondary">Sign up to accept invitation {inviteLink}</p>
+          </div>
+
+          <div className="my-5">
+            <h2 className="text-dark h4 mb-2">Welcome!</h2>
+            <p className="text-secondary">Click to create your Athenian account</p>
+          </div>
+
+          <button
+            type="button"
+            className="btn btn-xlarge btn-orange"
+            onClick={() => loginWithRedirect({ appState: { inviteLink } })}
+          >
+            Sign Up
+          </button>
+        </Simple>
+    );
+};
+
+const NoInvitation = () => (
+    <Simple>
+      <div className="my-5">
+        <h2 className="text-dark h4 mb-2">Welcome!</h2>
+        <p className="text-secondary">You need an invitation link to create your Athenian account</p>
+      </div>
+
+      <div className="my-5">
+        <a className="text-dark-orange" href="https://www.athenian.co">I don’t have an account</a>
+      </div>
+    </Simple>
+);

--- a/src/js/pages/pipeline/Filters.jsx
+++ b/src/js/pages/pipeline/Filters.jsx
@@ -27,7 +27,7 @@ const defaultDateInterval = {
 
 export default ({ children }) => {
     const { getTokenSilently } = useAuth0();
-    const userContext = useUserContext();
+    const { user } = useUserContext();
     const { reset: resetData, setGlobal: setGlobalData } = useDataContext();
 
     const [readyState, setReadyState] = useState(false);
@@ -43,9 +43,9 @@ export default ({ children }) => {
     const [filteredDateIntervalState, setFilteredDateIntervalState] = useState(defaultDateInterval);
 
     const context = {
-        account: userContext.defaultAccount.id,
+        account: user.defaultAccount.id,
         dateInterval: defaultDateInterval,
-        repos: userContext.defaultReposet.repos
+        repos: user.defaultReposet.repos
     };
 
     const reposSetters = {

--- a/src/js/pages/prototypes/ReleaseSettings.jsx
+++ b/src/js/pages/prototypes/ReleaseSettings.jsx
@@ -8,9 +8,9 @@ import { useUserContext } from 'js/context/User';
 import { Link } from 'react-router-dom';
 
 export default () => {
-  const userContext = useUserContext();
+  const { user } = useUserContext();
 
-  if (!userContext) return null;
+  if (!user) return null;
 
   return (
     <Page>
@@ -18,9 +18,9 @@ export default () => {
         <div className="col-2">
           <div className="card mb-5">
             <div className="card-header text-center bg-white">
-              <img className="rounded-circle mt-2 mb-4" src={userContext.picture || defaultImage} alt="" width="100" />
-              <h3 className="text-dark h5">{userContext.name}</h3>
-              <p className="text-secondary font-weight-light">{userContext.email}</p>
+              <img className="rounded-circle mt-2 mb-4" src={user.picture || defaultImage} alt="" width="100" />
+              <h3 className="text-dark h5">{user.name}</h3>
+              <p className="text-secondary font-weight-light">{user.email}</p>
             </div>
             <div className="card-body p-0">
               <div className="list-group list-group-flush">

--- a/src/js/pages/templates/Page.jsx
+++ b/src/js/pages/templates/Page.jsx
@@ -8,12 +8,12 @@ import Breadcrumbs from 'js/components/layout/Breadcrumbs';
 import Footer from 'js/components/layout/Footer';
 
 export default ({ children }) => {
-    const userContext = useUserContext();
+    const { user } = useUserContext();
     const breadcrumbs = useBreadcrumbsContext();
 
-    return userContext ? (
+    return user ? (
         <>
-          <Navbar user={userContext} />
+          <Navbar user={user} />
           <Breadcrumbs breadcrumbs={breadcrumbs} />
 
           <div className="container mt-4">
@@ -22,5 +22,5 @@ export default ({ children }) => {
 
           <Footer />
         </>
-    ) : <Navbar user={userContext} /> ;
+    ) : <Navbar user={user} /> ;
 };

--- a/src/js/pages/templates/Page.jsx
+++ b/src/js/pages/templates/Page.jsx
@@ -8,7 +8,7 @@ import Breadcrumbs from 'js/components/layout/Breadcrumbs';
 import Footer from 'js/components/layout/Footer';
 import Simple from 'js/pages/templates/Simple';
 
-export default ({ children }) => {
+export default ({ invitationDisabled, children }) => {
     const { user, isAuthenticated, logout } = useUserContext();
     const breadcrumbs = useBreadcrumbsContext();
 
@@ -25,7 +25,8 @@ export default ({ children }) => {
     }
 
     return (
-        <AuthenticatedWithUser user={user} breadcrumbs={breadcrumbs}>
+        <AuthenticatedWithUser user={user} breadcrumbs={breadcrumbs}
+                               invitationDisabled={invitationDisabled}>
           {children}
         </AuthenticatedWithUser>
     );
@@ -48,9 +49,9 @@ const AuthenticatedWithUserNoAccount = ({logout}) => (
     />
 );
 
-const AuthenticatedWithUser = ({user, breadcrumbs, children}) => (
+const AuthenticatedWithUser = ({user, breadcrumbs, invitationDisabled, children}) => (
     <>
-      <Navbar user={user} />
+      <Navbar user={user} invitationDisabled={invitationDisabled}/>
       <Breadcrumbs breadcrumbs={breadcrumbs} />
 
       <div className="container mt-4">

--- a/src/js/pages/templates/Page.jsx
+++ b/src/js/pages/templates/Page.jsx
@@ -65,6 +65,13 @@ const AuthenticatedWithUser = ({user, breadcrumbs, invitationDisabled, children}
 const AuthenticationError = ({message, logout}) => (
     <Simple>
       <p>{message}</p>
-      <button onClick={() => logout({ returnTo: window.ENV.auth.logoutRedirectUri })}>logout</button>
+
+      <button
+        type="button"
+        className="btn btn-xlarge btn-orange"
+        onClick={() => logout({ returnTo: window.ENV.auth.logoutRedirectUri })}
+      >
+        Logout
+      </button>
     </Simple>
 );

--- a/src/js/pages/templates/Page.jsx
+++ b/src/js/pages/templates/Page.jsx
@@ -6,21 +6,64 @@ import { useBreadcrumbsContext } from 'js/context/Breadcrumbs';
 import Navbar from 'js/components/layout/Navbar';
 import Breadcrumbs from 'js/components/layout/Breadcrumbs';
 import Footer from 'js/components/layout/Footer';
+import Simple from 'js/pages/templates/Simple';
 
 export default ({ children }) => {
-    const { user } = useUserContext();
+    const { user, isAuthenticated, logout } = useUserContext();
     const breadcrumbs = useBreadcrumbsContext();
 
-    return user ? (
-        <>
-          <Navbar user={user} />
-          <Breadcrumbs breadcrumbs={breadcrumbs} />
+    if (!isAuthenticated) {
+        return <NotAuthenticated/>;
+    }
 
-          <div className="container mt-4">
-            {children}
-          </div>
+    if (!user) {
+        return <AuthenticatedWithoutUser logout={logout}/>;
+    }
 
-          <Footer />
-        </>
-    ) : <Navbar user={user} /> ;
+    if (!user.defaultAccount) {
+        return <AuthenticatedWithUserNoAccount logout={logout} />;
+    }
+
+    return (
+        <AuthenticatedWithUser user={user} breadcrumbs={breadcrumbs}>
+          {children}
+        </AuthenticatedWithUser>
+    );
 };
+
+
+const NotAuthenticated = () => <Navbar />;
+
+const AuthenticatedWithoutUser = ({logout}) => (
+    <AuthenticationError
+      message="Authentication error. Please logout and use an invitation link."
+      logout={logout}
+    />
+);
+
+const AuthenticatedWithUserNoAccount = ({logout}) => (
+    <AuthenticationError
+      message="Your user was not invited to any account. You should accept an invitation first."
+      logout={logout}
+    />
+);
+
+const AuthenticatedWithUser = ({user, breadcrumbs, children}) => (
+    <>
+      <Navbar user={user} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} />
+
+      <div className="container mt-4">
+        {children}
+      </div>
+
+      <Footer />
+    </>
+);
+
+const AuthenticationError = ({message, logout}) => (
+    <Simple>
+      <p>{message}</p>
+      <button onClick={() => logout({ returnTo: window.ENV.auth.logoutRedirectUri })}>logout</button>
+    </Simple>
+);

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -47,7 +47,7 @@ export const getUserWithAccountRepos = async token => {
     Object.keys(user.accounts).map(accountID => getAccountRepos(accountID, user.accounts[accountID]))
   );
 
-  const defaultAccount = accounts[0] || { reposets: [] };
+  const defaultAccount = accounts[0];
   const defaultReposet = (defaultAccount && defaultAccount.reposets && defaultAccount.reposets[0]) || { repos: [] };
 
   return { ...user, accounts, defaultAccount, defaultReposet };

--- a/src/js/smart-components/InvitationCreator.jsx
+++ b/src/js/smart-components/InvitationCreator.jsx
@@ -18,14 +18,13 @@ export default ({ user, className }) => {
             return;
         };
 
-        const ownedAccount = getOwnedAccount(user);
-        if (!ownedAccount) {
+        if (!user.defaultAccount.isAdmin) {
             return;
-        };
+        }
 
         setLoadingState(true);
         getTokenSilently()
-            .then(token => getInvitation(token, ownedAccount.id))
+            .then(token => getInvitation(token, user.defaultAccount.id))
             .then(setUrlState)
             .catch(err => console.error("Could not get invitation", err))
             .finally(() => setLoadingState(false));
@@ -50,13 +49,3 @@ export default ({ user, className }) => {
             )
     );
 };
-
-const getOwnedAccount = user => {
-    for (let id in user.accounts) {
-        if (user.accounts[id].isAdmin) {
-            return user.accounts[id];
-        }
-    }
-
-    return null;
-}


### PR DESCRIPTION
Admins onboards will still redirect to waiting page, but it will still be possible to go to home page even without data ready until we don't fully implement progress polling.

## Features

- Better error handling during invitation creation
- New `/signup` route for invitations with update in copies
- Admin account is prioritized in case of multiple accounts
- Authenticaed users without an Athenian account are not allowed
- No more automatic logout in any case
- Disabled showing member invitation link in waiting page
- Styled logout button the same way the login one is

## Videos

- Admin link without error: https://streamable.com/r2v3ra
- Admin link with error: https://streamable.com/vg89ia
- Login without account: https://streamable.com/f4c5iv
- Normal member link without error: https://streamable.com/y0077b
- Normal member link with error: https://streamable.com/2jjfx9
- Signup without link: https://streamable.com/jo3jko

