### PR TITLE
Move component status into the StatusIndicator

### DIFF
--- a/src/js/components/DataWidget.jsx
+++ b/src/js/components/DataWidget.jsx
@@ -1,16 +1,17 @@
 import React, { useState, useEffect } from 'react';
+
 import { useDataContext } from 'js/context/Data';
-import { usePrevious } from 'js/hooks';
-import Spinner from 'js/components/ui/Spinner';
+import { StatusIndicator, READY, EMPTY, FAILED, LOADING } from 'js/components/ui/Spinner';
 
 export default ({id, component, fetcher, plumber, globalDataIDs, config, propagateSpinner = false}) => {
     const conf = config ? config : {};
     const { get: getData, getGlobal: getGlobalData, set: setData, globalDataReady } = useDataContext();
     const [dataState, setDataState] = useState(null);
-    const [loadingDataState, setLoadingDataState] = useState(false);
-    const prevLoadingDataState = usePrevious(loadingDataState);
+    const [statusState, setStatusState] = useState(LOADING);
+    const [errorState, setErrorState] = useState(null);
+    const [fetchingState, setFetchingState] = useState(false);
 
-    console.log("Rendering CHART", id, globalDataReady, prevLoadingDataState, loadingDataState, dataState);
+    console.log("Rendering CHART", id, globalDataReady, statusState, dataState);
 
     useEffect(() => {
         console.log("---> Rendering CHART: useEffect 1", id);
@@ -36,77 +37,66 @@ export default ({id, component, fetcher, plumber, globalDataIDs, config, propaga
                 console.log("---> Rendering CHART: useEffect 1 | async | fetching done", id);
                 console.log("---> Rendering CHART: useEffect 1 | async | set data", plumbedData);
                 setData(id, plumbedData);
-                console.log("---> Rendering CHART: useEffect 1 | async | set loading", false);
+                console.log("---> Rendering CHART: useEffect 1 | async | set status", READY);
             } catch (err) {
-                console.log("---> Rendering CHART: useEffect 1 | async | set error", err);
+                console.log("---> Rendering CHART: useEffect 1 | async | set error", FAILED);
                 setData(id, err);
             } finally {
-                setLoadingDataState(false);
+                setFetchingState(false);
             }
         };
 
         const data = getData(id);
         if (!data) {
             console.log("---> Rendering CHART: useEffect 1 | set data", null);
+            setStatusState(LOADING);
+            setErrorState(null);
             setDataState(null);
-            console.log("---> Rendering CHART: useEffect 1 | set loading", true);
+            console.log("---> Rendering CHART: useEffect 1 | set state", LOADING);
 
             if (!globalDataReady) {
                 console.log("---> Rendering CHART: useEffect 1 | waiting for global data", id, globalDataReady);
-            } else if (!loadingDataState) {
-                setLoadingDataState(true);
+            } else if (!fetchingState) {
+                setFetchingState(true);
                 fetchAndSetData();
             }
         } else {
-            console.log("---> Rendering CHART: useEffect 1 | found data", data);
-            setDataState(data);
+            let error, widgetData, status;
+            if (asError(data)) {
+                error = data;
+                status = FAILED;
+                console.error(error);
+            } else {
+                widgetData = data;
+                status = widgetData ? READY : EMPTY;
+            }
+
+            console.log(`---> Rendering CHART: useEffect 1 | found ${error ? 'error' : 'data'}:`, error ? error : widgetData);
+            console.log("---> Rendering CHART: useEffect 1 | set status", status);
+            setErrorState(error);
+            setStatusState(status);
+            setDataState(widgetData);
         }
-    }, [id, loadingDataState, getData, setData, fetcher, plumber, globalDataIDs, getGlobalData, globalDataReady]);
+    }, [ id, getData, setData, fetcher, plumber, globalDataIDs, getGlobalData, globalDataReady, fetchingState ]);
 
-    useEffect(() => {
-        console.log("---> Rendering CHART: useEffect 2", id, prevLoadingDataState, loadingDataState);
-        if (!loadingDataState && prevLoadingDataState) {
-            console.log("---> Rendering CHART: useEffect 2 | set data", getData(id));
-            setDataState(getData(id));
-        }
-    }, [id, getData, prevLoadingDataState, loadingDataState]);
-
-    const waiting = !dataState;
-    const spinner = buildSpinner(conf);
-
-    if (waiting && !propagateSpinner) {
-        return spinner;
+    if (statusState !== READY && !propagateSpinner) {
+        return <StatusIndicator status={statusState} />
     }
-
-    if (propagateSpinner) {
-        // this should be uniformed, not done yet for backward compatibility
-        conf.spinner = spinner;
-        conf.spinnerBuilder = buildSpinner;
-    }
-
-
 
     const Component = component;
-
-    let data, error;
-    if (dataState instanceof Error) {
-        data = null;
-        error = dataState;
-    } else {
-        data= dataState;
-        error = null;
-    }
-
-    return <Component data={data} loading={waiting} error={error} {...conf} />;
+    return <Component data={dataState} error={errorState} status={statusState} {...conf} />;
 };
 
-const buildSpinner = (conf) => {
-    const margin = conf.margin !== undefined ? conf.margin : 5;
-    return (
-        <div className={`row mt-${margin} mb-${margin} mx-auto align-middle`}>
-          <div className="col-12 text-center">
-            <Spinner loading={true} color={conf.color || 'black'} />
-          </div>
-        </div>
-    );
+const asError = something => {
+    if (!something) {
+        return null;
+    }
+
+    if (something instanceof Error) {
+        return something;
+    } else if (something.error) {
+        return something.error;
+    }
+
+    return null;
 };

--- a/src/js/components/pipeline/MainMetrics.jsx
+++ b/src/js/components/pipeline/MainMetrics.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DataWidget from 'js/components/DataWidget';
 import Badge, { NEGATIVE_IS_BETTER, POSITIVE_IS_BETTER } from 'js/components/ui/Badge';
+import { StatusIndicator, READY } from 'js/components/ui/Spinner';
 import { BigNumber, SmallTitle } from 'js/components/ui/Typography';
 import Info from 'js/components/ui/Info';
 
@@ -10,8 +11,7 @@ import { useApi } from 'js/hooks';
 
 import { dateTime, number } from 'js/services/format';
 
-
-const MainMetrics = ({ data, loading, spinner }) => {
+const MainMetrics = ({ data, status }) => {
     return (
         <div className="row mb-4">
           <div className="col-md-3">
@@ -19,8 +19,7 @@ const MainMetrics = ({ data, loading, spinner }) => {
               title="Lead time"
               hint="Elapsed time between the creation of the 1st commit in a pull request and the code being used in production."
               dataGetter={() => [dateTime.human(data.leadTime.avg), data.leadTime.variation]}
-              spinner={spinner}
-              loading={loading}
+              status={status}
               negativeIsBetter
             />
           </div>
@@ -29,8 +28,7 @@ const MainMetrics = ({ data, loading, spinner }) => {
               title="Cycle time"
               hint="Sum of the average time required in each development stage."
               dataGetter={() => [dateTime.human(data.cycleTime.avg), data.cycleTime.variation]}
-              spinner={spinner}
-              loading={loading}
+              status={status}
               negativeIsBetter
             />
           </div>
@@ -39,8 +37,7 @@ const MainMetrics = ({ data, loading, spinner }) => {
               title="Pull requests"
               hint="Number of pull requests released, counting in the Lead Time."
               dataGetter={() => [data.releasedPRs.avg, data.releasedPRs.variation]}
-              spinner={spinner}
-              loading={loading}
+              status={status}
             />
           </div>
           <div className="col-md-3">
@@ -48,18 +45,17 @@ const MainMetrics = ({ data, loading, spinner }) => {
               title="Contributors"
               hint="Number of people involved in delivering software."
               dataGetter={() => [data.contribs.avg, data.contribs.variation]}
-              spinner={spinner}
-              loading={loading}
+              status={status}
             />
           </div>
         </div >
     );
 };
 
-const MainMetric = ({ title, hint, dataGetter, loading, spinner, negativeIsBetter = false }) => {
+const MainMetric = ({ title, hint, dataGetter, status, negativeIsBetter = false }) => {
     let content;
-    if (loading && spinner) {
-        content = spinner;
+    if (status !== READY) {
+        content = <StatusIndicator status={status} margin={0} textOnly />;
     } else {
         const [value, variation] = dataGetter();
         content = (
@@ -146,10 +142,6 @@ export default () => {
           id={`main-metrics`}
           component={MainMetrics} fetcher={fetcher} plumber={plumber}
           globalDataIDs={['filter.contribs', 'prs-metrics.values', 'prs-metrics.variations']}
-          config={{
-              margin: 0,
-              color: '#858796',
-          }}
           propagateSpinner={true}
         />
     );

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -9,8 +9,7 @@ import { prLabel, PR_STATUS as prStatus, PR_LABELS_CLASSNAMES as prLabelClasses 
 
 import _ from 'lodash';
 
-import { NoData } from 'js/components/layout/Empty';
-import Spinner from 'js/components/ui/Spinner';
+import { StatusIndicator, READY } from 'js/components/ui/Spinner';
 
 const userImage = users => user => {
     if (users[user] && users[user].avatar) {
@@ -28,26 +27,22 @@ const userImage = users => user => {
 const tableContainerId = 'dataTable';
 const tableContainerSelector = `#${tableContainerId}`;
 
-export default ({ stage, data, loading }) => {
+export default ({ stage, data, status }) => {
     useEffect(() => {
-        if (loading || !data?.prs?.length) {
+        if (status !== READY) {
             return;
         }
+
         draw(stage, data);
         return () => {
             $.fn.DataTable.isDataTable(tableContainerSelector) && $(tableContainerSelector).DataTable().destroy();
             $(tableContainerSelector).empty();
         };
-    }, [stage, data, loading]);
+    }, [stage, data, status]);
 
     return (
         <>
-            {loading && (
-                <div className="text-center">
-                    <Spinner loading={loading} color="black" />
-                </div>
-            )}
-            {!loading && !data?.prs?.length && <NoData />}
+            <StatusIndicator status={status} textOnly={false} />
             <div className="table-responsive mb-4">
                 <table className="table table-bordered" id={tableContainerId} width="100%" cellSpacing="0" style={{ tableLayout: 'fixed' }} />
             </div>

--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -6,6 +6,7 @@ import { useApi } from 'js/hooks';
 import { BigNumber } from 'js/components/ui/Typography';
 import { pipelineStagesConf } from 'js/pages/pipeline/Pipeline';
 import { SmallTitle } from 'js/components/ui/Typography';
+import { StatusIndicator, READY } from 'js/components/ui/Spinner';
 import DataWidget from 'js/components/DataWidget';
 import { dateTime, number } from 'js/services/format';
 import { palette } from 'js/res/palette';
@@ -109,12 +110,7 @@ export const OverviewSummaryMetrics = ({name, metric}) => {
     );
 };
 
-const SummaryMetrics = ({ data, stage, KPIComponent, loading, spinnerBuilder, chartConfig }) => {
-    const spinner = spinnerBuilder({
-        margin: 5,
-        color: chartConfig.color
-    });
-
+const SummaryMetrics = ({ data, stage, KPIComponent, status, chartConfig }) => {
     return (
         <div className={classnames('summary-metric card mb-4 px-2', stage.stageName)}>
           <div className="card-body" style={{minHeight: '305px'}}>
@@ -122,7 +118,7 @@ const SummaryMetrics = ({ data, stage, KPIComponent, loading, spinnerBuilder, ch
               <div className="col-4">
                 <header className="font-weight-bold text-lg mt-2">{stage.summaryMetricTitle || stage.title}</header>
                 {
-                    !loading &&
+                    status === READY &&
                         <div className="pl-2">
                           <div className="font-weight-bold mt-4 mb-3 pb-2 border-bottom">
                             <BigNumber content={dateTime.human(data.average * 1000)} isXL />
@@ -135,14 +131,14 @@ const SummaryMetrics = ({ data, stage, KPIComponent, loading, spinnerBuilder, ch
                 }
               </div>
               {
-                  !loading &&
+                  status === READY &&
                       <div className="col-8 align-self-center">
                         <FilledAreaChart data={{timeseries: data.timeseries, average: data.average}} {...chartConfig}/>
                       </div>
               }
             </div>
 
-            {loading && spinner}
+            {status !== READY && <StatusIndicator status={status} color={chartConfig.color} />}
           </div>
         </div>
     );

--- a/src/js/components/ui/Spinner.jsx
+++ b/src/js/components/ui/Spinner.jsx
@@ -1,14 +1,43 @@
 import React from 'react';
+import classnames from 'classnames';
 
 import BeatLoader from "react-spinners/BeatLoader";
 
-const DEFAULT_SIZE = 10;
-const DEFAULT_COLOR = "#FF6C37";
+import { palette } from 'js/res/palette';
+import { NoData } from 'js/components/layout/Empty';
 
-export default ({loading, size, color}) => (
-    <BeatLoader
-      size={size || DEFAULT_SIZE}
-      color={color || DEFAULT_COLOR}
-      loading={loading}
-    />
+const DEFAULT_SIZE = 10;
+const DEFAULT_COLOR = palette.schemes.grey;
+
+export const READY = 'ready';
+export const LOADING = 'loading';
+export const FAILED = 'failed';
+export const EMPTY = 'empty';
+
+const Spinner = ({loading, size = DEFAULT_SIZE, color = DEFAULT_COLOR}) => (
+    <BeatLoader size={size} color={color} loading={loading} />
 );
+
+export default Spinner;
+
+export const StatusIndicator = ({ status, color = DEFAULT_COLOR, margin = 5, textOnly = false }) => {
+  let message;
+  switch (status) {
+      case LOADING:
+          message = <Spinner loading={true} color={color} />;
+          break;
+      case FAILED:
+          message = 'error loading data';
+          break;
+      case EMPTY:
+          message = <NoData textOnly={textOnly} />;
+          break;
+      case READY:
+      default:
+          return null;
+  };
+
+  return (
+    <div className={classnames(`my-${margin}`, 'mx-auto align-middle text-center')}>{message}</div>
+  );
+};

--- a/src/js/pages/pipeline/Body.jsx
+++ b/src/js/pages/pipeline/Body.jsx
@@ -1,16 +1,17 @@
 import React, {useEffect} from 'react';
 import { useParams } from "react-router-dom";
-
-import MainMetrics from 'js/components/pipeline/MainMetrics';
-import Thumbnails from 'js/components/pipeline/Thumbnails';
-import { useApi } from 'js/hooks';
-import { useDataContext } from 'js/context/Data';
-import { fetchFilteredPRs, fetchPRsMetrics, getPreviousInterval } from 'js/services/api';
 import _ from "lodash";
 import moment from 'moment';
 
-
+import MainMetrics from 'js/components/pipeline/MainMetrics';
+import Thumbnails from 'js/components/pipeline/Thumbnails';
 import { pipelineStagesConf, getStage } from 'js/pages/pipeline/Pipeline';
+
+import { useApi } from 'js/hooks';
+import { useDataContext } from 'js/context/Data';
+import { fetchFilteredPRs, fetchPRsMetrics, getPreviousInterval } from 'js/services/api';
+
+import { NoData } from 'js/components/layout/Empty';
 
 export default ({ children }) => {
     const { api, ready: apiReady, context: apiContext } = useApi();
@@ -155,6 +156,10 @@ export default ({ children }) => {
         fetchGlobalPRMetrics();
         fetchGlobalPRMetricsVariations();
     }, [apiReady, api, apiContext.account, apiContext.interval, apiContext.repositories, apiContext.contributors, setGlobalData]);
+
+    if (!apiContext?.repositories?.length) {
+        return <NoData />;
+    }
 
     return (
         <>

--- a/src/js/res/palette.js
+++ b/src/js/res/palette.js
@@ -4,6 +4,7 @@ const third = '#4DC7EE';
 const fourth = '#2FCC71';
 const alert = '#F37373';
 const alertStrong = '#EF3837';
+const grey = '#8889A1'; // $color-secondary
 
 export const palette = {
     stages: {
@@ -16,7 +17,8 @@ export const palette = {
         done: '#24C7CC',
     },
     schemes: {
-        primary: primary,
+        primary,
+        grey,
         trend: secondary,
         duoSimilar: [secondary, third],
         duoContrast: [primary, third],


### PR DESCRIPTION
fix [[ENG-584]], [[ENG-585]] and [[ENG-719]]

Recognize different possible statuses in components and show them in the StatusIndicator.
If there are no repos available for the given filters, it hides the rest of the Pipeline Body as in the following screenshot:

![image](https://user-images.githubusercontent.com/2437584/80918893-7efed800-8d67-11ea-8a3b-ddc4dea71180.png)

[ENG-584]: https://athenianco.atlassian.net/browse/ENG-584
[ENG-585]: https://athenianco.atlassian.net/browse/ENG-585
[ENG-719]: https://athenianco.atlassian.net/browse/ENG-719