### PR TITLE
feat(ENG-687): Add developer names to filter

### DIFF
--- a/src/js/pages/pipeline/Filters.jsx
+++ b/src/js/pages/pipeline/Filters.jsx
@@ -150,7 +150,12 @@ export default ({ children }) => {
                   noDataMsg="There are no contributors for the date interval and repositories filters"
                   options={allContribsState}
                   isReady={contribsReadyState}
-                  labelFormat={repo => (github.userName(repo) || 'ANONYMOUS')}
+                  labelFormat={({ realName, login }) => {
+                    const gituser = github.userName(login)
+                    const names = [gituser || 'ANONYMOUS']
+                    realName && gituser !== realName && names.push(`(${realName})`)
+                    return names.join(" ")
+                  }}
                   onChange={onContribsChange}
                 />
             }

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -86,7 +86,10 @@ export const getContributors = (token, userAccount, from, to, repos) => {
         api, userAccount,
         {from: new Date(from), to: new Date(to)},
         {repositories:repos}
-    ).then(contribs => contribs.map(c => c.login));
+    ).then(contribs => contribs.map(c => ({
+      login: c.login,
+      realName: c.name
+    })));
 };
 
 export const getInvitation = async (token, accountID) => {


### PR DESCRIPTION
Closes: https://athenianco.atlassian.net/browse/ENG-687

Only show the extra name if login and name are differente. example attached: dependabot-preview does not have an extra name since it'll be dependabot-preview (dependabot-preview)

<img width="314" alt="Screen Shot 2020-05-04 at 17 58 07" src="https://user-images.githubusercontent.com/745366/81013306-50e5ca80-8e31-11ea-8ae6-0fdf8ed50927.png">