### PR TITLE
Read API errors

### DIFF
--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -38,7 +38,7 @@ export const reportToSentry = (error, context = {}) => Sentry.withScope(scope =>
     Sentry.captureException(error);
 });
 
-const withSentryCapture = (p, message) => p.catch(e => {
+const withSentryCapture = (p, message, rethrow = false) => p.catch(e => {
     if (e instanceof Error) {
         reportToSentry(e);
     } else {
@@ -54,6 +54,10 @@ const withSentryCapture = (p, message) => p.catch(e => {
         };
 
         reportToSentry(err, sentryCtx);
+    }
+
+    if (rethrow) {
+      throw e;
     }
 });
 
@@ -347,6 +351,7 @@ export const saveRepoSettings = async (api, accountId, repos, strategy, branchPa
 
   return withSentryCapture(
     api.setReleaseMatch({ body: repoSettings }),
-    "Cannot set release match"
+    "Cannot set release match",
+    true,
   );
 };

--- a/src/js/services/logger.jsx
+++ b/src/js/services/logger.jsx
@@ -58,7 +58,7 @@ const extractParts = item => {
 const errorParts = err => {
     let parts = [];
     const baseError = errMessage(err);
-    const causeError = errMessage(err.original);
+    const causeError = err.original && errMessage(err.original);
 
     if (baseError) {
         parts.push(baseError);

--- a/src/js/services/logger.jsx
+++ b/src/js/services/logger.jsx
@@ -24,5 +24,51 @@ export default {
 };
 
 const Msgs = ({ msgs }) => {
-    return msgs.map((msg, key) => <div key={key}>{msg.toString()}</div>);
+    const messages = msgs.reduce((acc, item) => { acc.push(...extractParts(item)); return acc; }, []);
+    return messages.map((msg, key) => <div key={key}>{msg}</div>);
 }
+
+const extractParts = item => {
+    if (!item) {
+        return [];
+    }
+
+    if (['number', 'string'].includes(typeof item)) {
+        return [item];
+    }
+
+    if (item.body?.title && item.body?.type) {
+        // errors returned by the API, as proper HTTP response (see API errors schema)
+        const parts = [];
+        parts.push(item.body.detail);
+        parts.push(`${item.body.title}. ${item.body.type}`);
+        return parts.filter(v => !!v);
+    }
+
+    if (item.error) {
+        // e.g. when JSON response could not be parsed (e.g. API returning NaN for old go-git '/filter/pull_requests')
+        let parts = errorParts(item.error);
+        return parts.length ? parts : ['Unhandled error'];
+    }
+
+    // errors or error-like
+    return errorParts(item);
+};
+
+const errorParts = err => {
+    let parts = [];
+    const baseError = errMessage(err);
+    const causeError = errMessage(err.original);
+
+    if (baseError) {
+        parts.push(baseError);
+    }
+
+    if (causeError) {
+        parts.push(causeError);
+    }
+
+    return parts;
+}
+
+const errMessage = err => err instanceof Error ? err.toString() : err.message;


### PR DESCRIPTION
Errors returned by the API, contains their details under error.body
Errors caused while parsing the response (e.g. JSON decode errors), are under err.error
Plain errors are also stringed with its original cause, if it exists
Strings and numbers are left untouched
