### PR TITLE
Enable 'Settings' in user menu. Hide 'Teams' menu

### DIFF
--- a/src/js/components/layout/Navbar.jsx
+++ b/src/js/components/layout/Navbar.jsx
@@ -36,6 +36,9 @@ const User = ({ user, invitationDisabled }) => {
             </div>
           </header>
           {!invitationDisabled && <InvitationCreator user={user} className="menuItem py-3" />}
+          <div className="d-flex flex-row d-flex justify-content-between align-items-center font-weight-light text-s menuItem py-3 border-top">
+            <Link to="/settings" className="text-dark">Settings</Link>
+          </div>
           <footer className="menuItem d-flex flex-row align-items-center justify-content-end bg-light py-2 text-xs border-top">
             <Link to="/logout" className="text-s text-secondary">Logout</Link>
           </footer>

--- a/src/js/pages/Settings.jsx
+++ b/src/js/pages/Settings.jsx
@@ -25,6 +25,8 @@ export const getOrg = user => {
 export default ({ children }) => {
   const { user } = useUserContext();
 
+  const isDev = window.ENV.environment === 'development' || process.env.NODE_ENV === 'development';
+
   if (!user) return <Page />;
 
   return (
@@ -40,7 +42,7 @@ export default ({ children }) => {
             <div className="card-body p-0">
               <div className="list-group list-group-flush">
                 <NavLink className="list-group-item py-2" to="/settings/profile">Profile</NavLink>
-                <NavLink className="list-group-item py-2" to="/settings/teams">Teams</NavLink>
+                {isDev && <NavLink className="list-group-item py-2" to="/settings/teams">Teams</NavLink>}
                 <NavLink className="list-group-item py-2" to="/settings/releases">Releases</NavLink>
                 <Link to="/logout" className="list-group-item bg-light text-right py-2 rounded-bottom">Logout</Link>
               </div>


### PR DESCRIPTION
This PR will enable the link to `Settings` in the user menu, and hide the `Teams` link in the Settings aside in Production.
https://app.athenian.co/settings/team route will still be accessible by direct url.


![image](https://user-images.githubusercontent.com/2437584/81641779-1af0a980-9422-11ea-927d-139e181f6b14.png)


![image](https://user-images.githubusercontent.com/2437584/81641762-0f04e780-9422-11ea-900c-5a9ed8cd2f57.png)
