### PR TITLE
Flags to detect development or not Prod

### DIFF
--- a/src/js/components/development/index.jsx
+++ b/src/js/components/development/index.jsx
@@ -3,6 +3,10 @@ import { useAuth0 } from 'js/context/Auth0';
 import Simple from 'js/pages/templates/Simple';
 import 'js/components/development/index.scss';
 
+export const isDev = process.env.NODE_ENV === 'development';
+
+export const isNotProd = ['development', 'staging'].includes(window.ENV?.environment);
+
 export default {
     Breakpoints: () => (
         <div id="breakpoint-helper">


### PR DESCRIPTION
`Development.isDev` returns `true` only if running with webpack server
`Development.isNotProd` returns `true` only if `process.env.NODE_ENV` is set to `development` or `staging` (e.g. through `public/config.js`)
