### PR TITLE
Handle empty badges

### DIFF
--- a/src/js/components/development/index.jsx
+++ b/src/js/components/development/index.jsx
@@ -59,5 +59,7 @@ export default {
       (async () => setToken(await getTokenSilently()))();
 
       return <Simple><pre className="bearer-token">{token}</pre></Simple>;
-    }
+    },
+
+    errorBoxClass: isNotProd && 'development-error-box',
 };

--- a/src/js/components/development/index.scss
+++ b/src/js/components/development/index.scss
@@ -87,3 +87,12 @@
     margin-left: auto;
     margin-right: auto;
 }
+
+.development-error-box {
+    border: 2px solid red;
+    background-color: yellow;
+
+    &:empty:before {
+        content: 'error';
+    }
+}

--- a/src/js/components/insights/KPI.jsx
+++ b/src/js/components/insights/KPI.jsx
@@ -39,7 +39,7 @@ import { number } from 'js/services/format';
 export const SimpleKPI = ({params}) => (
     <div className="font-weight-bold">
       <BigNumber content={buildContent(params.value, getUnit(params.value, params.unit))} />
-      {params.variation && <Badge value={number.round(params.variation)} trend={params.variationMeaning} className="ml-2" />}
+      <Badge value={number.round(params.variation)} trend={params.variationMeaning} className="ml-2" />
     </div>
 );
 

--- a/src/js/components/layout/Tabs.jsx
+++ b/src/js/components/layout/Tabs.jsx
@@ -22,9 +22,7 @@ export default ({ tabs }) => {
                         >
                             <div className="card-body px-0 py-3">
                                 <SmallTitle content={tab.title} isBlack={activeTabState === i && 'active'} />
-                                {tab.badge ? (
-                                    <Badge value={tab.badge} className="ml-3" />
-                                ) : null}
+                                <Badge value={tab.badge} className="ml-3" />
                             </div>
                         </div>
                     ))}

--- a/src/js/components/pipeline/MainMetrics.jsx
+++ b/src/js/components/pipeline/MainMetrics.jsx
@@ -61,11 +61,11 @@ const MainMetric = ({ title, hint, dataGetter, status, negativeIsBetter = false 
         content = (
             <>
               <BigNumber content={value} />
-              {value ? <Badge
-                         value={number.round(variation)}
-                         trend={negativeIsBetter ? NEGATIVE_IS_BETTER : POSITIVE_IS_BETTER}
-                         className="ml-4"
-                       /> : ''}
+              <Badge
+                value={number.round(variation)}
+                trend={negativeIsBetter ? NEGATIVE_IS_BETTER : POSITIVE_IS_BETTER}
+                className="ml-4"
+              />
             </>
         );
     }

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -66,7 +66,7 @@ const Stage = ({ data, status, title, text, hint, badge, variation, color, activ
             <>
             <div className="col-5">
                 <BigNumber content={text} className="mb-1 w-100" />
-                {text ? <Badge trend={NEGATIVE_IS_BETTER} value={number.round(variation)} /> : ''}
+                <Badge trend={NEGATIVE_IS_BETTER} value={number.round(variation)} />
             </div>
             <div className="col-7 pl-2" style={{ height: 55 }}>
                 <PipelineCardMiniChart data={data} config={{color}} />
@@ -82,7 +82,7 @@ const Stage = ({ data, status, title, text, hint, badge, variation, color, activ
                         <SmallTitle content={title} />
                         <Info content={hint} />
                     </span>
-                    {status === READY && badge && <Badge value={badge} />}
+                    {status === READY && <Badge value={badge} />}
                 </div>
                 <div className="row no-gutters card-text">
                   {content}

--- a/src/js/components/ui/Badge.jsx
+++ b/src/js/components/ui/Badge.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import classnames from 'classnames';
-
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
+
+import { isNumber } from 'js/services/format';
+import { reportToSentry } from 'js/services/api';
+
+import development from 'js/components/development';
 
 export const POSITIVE_IS_BETTER = 'positive-variation-is-better'; // default
 export const NEGATIVE_IS_BETTER = 'negative-variation-is-better';
@@ -11,16 +15,27 @@ export default ({ value, trend = false, className }) => {
   const commonClasses = ['badge', 'font-weight-normal', 'align-middle', 'd-inline-block'];
   let customClasses, icon;
   let suffix = '%';
+
+  if (typeof value === 'number' && !isFinite(value)) {
+    const err = new Error(`Not a valid number in a Badge; got "${value}" instead`);
+    reportToSentry(err);
+    return  <span className={classnames(className, ...commonClasses, development.errorBoxClass)} />;
+  }
+
+  if (!isNumber(value) && (typeof value !== 'string' || value === '')) {
+    return '';
+  }
+
   if (!trend) {
     customClasses = ['badge-pill', 'badge-secondary', 'py-1', 'px-2'];
+  } else if (value === 0 || !isNumber(value) ) {
+    return '';
   } else if (value < 0) {
     customClasses = [trend === NEGATIVE_IS_BETTER ? 'badge-success' : 'badge-danger'];
     icon = faCaretDown;
-  } else if (value > 0) {
+  } else {
     customClasses = [trend === NEGATIVE_IS_BETTER ? 'badge-danger' : 'badge-success'];
     icon = faCaretUp;
-  } else {
-    return '';
   }
 
   return (

--- a/src/js/components/ui/Typography.jsx
+++ b/src/js/components/ui/Typography.jsx
@@ -4,11 +4,11 @@ import classnames from 'classnames';
 export const nbsp = '\u00A0';
 
 export const BigNumber = ({ content, isXL, className }) => (
-    <span className={classnames('big-number font-weight-bold d-inline-block align-middle text-gray-900', isXL ? 'text-xl' : 'text-lg', className)}>{content || nbsp}</span>
+    <span className={classnames('big-number font-weight-bold d-inline-block align-middle text-gray-900', isXL ? 'text-xl' : 'text-lg', className)}>{content}</span>
 );
 
 export const SmallTitle = ({ content, isBlack, className }) => (
-    <span className={classnames('small-title font-weight-bold text-xs text-uppercase align-middle', isBlack && 'text-gray-900', className)}>{content || nbsp}</span>
+    <span className={classnames('small-title font-weight-bold text-xs text-uppercase align-middle', isBlack && 'text-gray-900', className)}>{content}</span>
 );
 
 export const AltTitle = ({ uppercase = false, content }) => (

--- a/src/js/services/format.js
+++ b/src/js/services/format.js
@@ -130,7 +130,7 @@ const round = (n, decimals = 0) => {
     return Math.round(n * Math.pow(10, decimals)) / Math.pow(10, decimals);
 };
 
-const isNumber = n => typeof n === 'number' && isFinite(n);
+export const isNumber = n => typeof n === 'number' && isFinite(n);
 
 export const number = {
     si: n => {

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -100,6 +100,14 @@ html {
 
 .small-title {
     line-height: 2rem;
+
+    &:empty:after {
+        content: '\00a0';
+    }
+}
+
+.big-number:empty:after {
+    content: '\00a0';
 }
 
 // Link colors

--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -126,4 +126,12 @@
             color: rgba($color-dark, 0.8);
         }
     }
+
+    &:empty {
+        display: none !important;
+
+        &.development-error-box {
+            display: inline-block !important;
+        }
+    }
 }


### PR DESCRIPTION
addresses [[ENG-477]] Remove the diff badges when there is no data to compare  
addresses [[ENG-481]] NaN in the "Proportion of the cycle time"
addresses [[ENG-779]] Fix the NAN and style the tooltip of the Lead Time distribution chart

`Badge` component is now responsible for rendering the badge if it received a number (or also string if it is not in `trend` mode). If it received a `NaN` or a `+-Infinite` it will send it as an error to Sentry because it will mean that a division by zero, or a wrong division happened.

You can see below the before, and after (in not Prod env; if it would be rendered in Prod, the error highlight won't be visible)
![image](https://user-images.githubusercontent.com/2437584/81839177-7b2d3b80-9547-11ea-8009-5896b76adaf2.png)

Also, **when it is not in Production**, such `NaN` or a `+-Infinite` errors will be highlighted as in the following screenshot, letting the developer or Product know that something was not properly calculated.
![image](https://user-images.githubusercontent.com/2437584/81847185-8be3ae80-9553-11ea-833f-7d874610347a.png)





[ENG-477]: https://athenianco.atlassian.net/browse/ENG-477
[ENG-481]: https://athenianco.atlassian.net/browse/ENG-481


[ENG-779]: https://athenianco.atlassian.net/browse/ENG-779