### PR TITLE
Handle badge errors

### DIFF
--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -32,6 +32,12 @@ if (window.ENV.sentry.dsn) {
     }
 
     Sentry.init(sentryConf);
+
+    if (window.ENV.sentry.developer) {
+        Sentry.configureScope(function(scope) {
+            scope.setTag('developer', window.ENV.sentry.developer);
+        });
+    }
 }
 
 toast.configure();

--- a/src/js/components/insights/KPI.jsx
+++ b/src/js/components/insights/KPI.jsx
@@ -39,7 +39,7 @@ import { number } from 'js/services/format';
 export const SimpleKPI = ({params}) => (
     <div className="font-weight-bold">
       <BigNumber content={buildContent(params.value, getUnit(params.value, params.unit))} />
-      <Badge value={number.round(params.variation)} trend={params.variationMeaning} className="ml-2" />
+      {typeof params.variation !== 'undefined' && <Badge value={number.round(params.variation)} trend={params.variationMeaning} className="ml-2" />}
     </div>
 );
 

--- a/src/js/components/insights/stages/work-in-progress/mostActiveDevs.jsx
+++ b/src/js/components/insights/stages/work-in-progress/mostActiveDevs.jsx
@@ -90,6 +90,8 @@ const mostActiveDevs = {
                         params: {
                             value: computed.activeDevs.length > 0 ?
                                 number.fixed(computed.totalPRs / computed.activeDevs.length, 2) : 0,
+                                variation: NaN,
+                                variationMeaning: true,
                         }
                     },
                 ]

--- a/src/js/components/ui/Badge.jsx
+++ b/src/js/components/ui/Badge.jsx
@@ -1,25 +1,31 @@
 import React from 'react';
+
 import classnames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons';
 
 import { isNumber } from 'js/services/format';
-import { reportToSentry } from 'js/services/api';
 
-import development from 'js/components/development';
+import ErrorBoundary from 'js/smart-components/ErrorBoundary';
 
 export const POSITIVE_IS_BETTER = 'positive-variation-is-better'; // default
 export const NEGATIVE_IS_BETTER = 'negative-variation-is-better';
 
 export default ({ value, trend = false, className }) => {
+  return (
+    <ErrorBoundary>
+      <BadgeInternal value={value} trend={trend} className={className} />
+    </ErrorBoundary>
+  );
+};
+
+const BadgeInternal = ({ value, trend = false, className }) => {
   const commonClasses = ['badge', 'font-weight-normal', 'align-middle', 'd-inline-block'];
   let customClasses, icon;
   let suffix = '%';
 
   if (typeof value === 'number' && !isFinite(value)) {
-    const err = new Error(`Not a valid number in a Badge; got "${value}" instead`);
-    reportToSentry(err);
-    return  <span className={classnames(className, ...commonClasses, development.errorBoxClass)} />;
+    throw new Error(`Not a valid number in a Badge; got "${value}" instead`);
   }
 
   if (!isNumber(value) && (typeof value !== 'string' || value === '')) {

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -43,34 +43,6 @@ export const PR_EVENT = {
   RELEASE: 'release_happened',
 };
 
-const PR_STAGE_EVENTS = {
-    [PR_STAGE.WIP]: {
-        start: PR_EVENT.COMMIT,
-        end: PR_EVENT.REVIEW_REQUEST,
-        others: [PR_EVENT.CREATION],
-    },
-    [PR_STAGE.REVIEW]: {
-        start: PR_EVENT.REVIEW_REQUEST,
-        end: PR_EVENT.APPROVE,
-        others: [PR_EVENT.REVIEW, PR_EVENT.REJECTION],
-    },
-    [PR_STAGE.MERGE]: {
-        start: PR_EVENT.APPROVE,
-        end: PR_EVENT.MERGE,
-        others: []
-    },
-    [PR_STAGE.RELEASE]: {
-        start: PR_EVENT.MERGE,
-        end: PR_EVENT.RELEASE,
-        others: []
-    },
-    [PR_STAGE.DONE]: {
-        start: null,
-        end: null,
-        others: []
-    },
-};
-
 // These are the PR labels that will appear in PR tables depending on pr status/stage/events
 // and depending from which stage the PR is analyzed (see: https://athenianco.atlassian.net/browse/ENG-325)
 export const PR_LABELS = {

--- a/src/js/smart-components/ErrorBoundary.jsx
+++ b/src/js/smart-components/ErrorBoundary.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import development, { isNotProd } from 'js/components/development';
+
+import { reportToSentry } from 'js/services/api';
+
+export default class extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { err: null };
+  }
+
+  static getDerivedStateFromError(err) {
+    return { err };
+  }
+
+  componentDidCatch(err, stack) {
+    reportToSentry(err, { extra: { stack: stack.componentStack } });
+  }
+
+  render() {
+    if (this.state.err) {
+      return (
+        <div
+          className={classnames('d-inline-block p-1', development.errorBoxClass)}
+          title={this.state.err.toString()}
+        >
+          {isNotProd && 'error'}
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
fix [[ENG-844]] Metric computational errors displayed as yellow badges in the UI

In order to catch Render stack traces, it is needed to use an [Error Boundary](https://reactjs.org/docs/error-boundaries.html) as done in 566fe6c

Some errors were thrown because `<SimpleKPI>` tries to render a variation `<Badge>` no matter it exists or not. Fixed by f009318 

## Other relevant features:
- ff429a0 Add developer id to sentry log as done in API

## TODO:
- 91bc364 This commit emulates an error in `<Badge>` for Sentry, which will be deleted by https://github.com/athenianco/athenian-webapp/pull/337 once confirmed it's properly handled by Sentry.


[ENG-844]: https://athenianco.atlassian.net/browse/ENG-844