### PR TITLE
New alert styling and copy

### DIFF
--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -1,7 +1,7 @@
 /* global process */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ToastContainer, toast } from 'react-toastify';
+import { ToastContainer, toast, Slide } from 'react-toastify';
 
 import {
     Router,
@@ -63,7 +63,16 @@ ReactDOM.render(<>
       </Router>
     </React.StrictMode>
   </Auth0Provider>
-  <ToastContainer />
+  <ToastContainer
+      position="top-center"
+      hideProgressBar
+      closeOnClick
+      pauseOnFocusLoss={true}
+      draggable={false}
+      pauseOnHover={true}
+      transition={Slide}
+      closeButton={false}
+  />
   {process.env.NODE_ENV === 'development' && <Development.Breakpoints />}
 </>,
   document.getElementById('root')

--- a/src/js/App.jsx
+++ b/src/js/App.jsx
@@ -66,12 +66,12 @@ ReactDOM.render(<>
   <ToastContainer
       position="top-center"
       hideProgressBar
+      closeButton={false}
       closeOnClick
-      pauseOnFocusLoss={true}
       draggable={false}
+      pauseOnFocusLoss={true}
       pauseOnHover={true}
       transition={Slide}
-      closeButton={false}
   />
   {process.env.NODE_ENV === 'development' && <Development.Breakpoints />}
 </>,

--- a/src/js/pages/settings/Releases.jsx
+++ b/src/js/pages/settings/Releases.jsx
@@ -24,6 +24,10 @@ const placeholderPatterns = {
   [TAG]: '.*',
 };
 
+const MESSAGES = {
+  SUCCESS: 'Settings updated',
+};
+
 const isFilteredIn = (conf, term) => !term ||
   github.repoName(conf.url).toLowerCase().includes(term.toLowerCase());
 
@@ -126,10 +130,9 @@ const RepoConfig = ({ accountId, config, filterTerm }) => {
       if (strategy === AUTOMATIC) {
         setBranchState(defaultPatterns[BRANCH]);
         setTagsState(defaultPatterns[TAG]);
-        log.ok(`Releases from "${config.url}" will be guessed automatically from tags or default branch if there are no tags available`);
-      } else {
-        log.ok(`Releases from "${config.url}" will be read from "${strategy}"`);
       }
+
+      log.ok(MESSAGES.SUCCESS);
     } catch (e) {
       if (strategy === AUTOMATIC) {
         log.fatal(`Could not save the new settings to automatically read new releases of "${config.url}"`, e);
@@ -157,11 +160,7 @@ const RepoConfig = ({ accountId, config, filterTerm }) => {
           throw new Error('Automatic strategy does not support patterns');
       }
       onSuccess && onSuccess();
-      if (strategy === AUTOMATIC) {
-        log.ok(`Releases from "${config.url}" will be guessed automatically from tags or default branch if there are no tags available`);
-      } else {
-        log.ok(`Releases from "${config.url}" will be read from "${strategy}" using "${pattern}"`);
-      }
+      log.ok(MESSAGES.SUCCESS);
     } catch (e) {
       onError && onError();
       if (strategy === AUTOMATIC) {

--- a/src/js/pages/settings/Releases.jsx
+++ b/src/js/pages/settings/Releases.jsx
@@ -134,11 +134,7 @@ const RepoConfig = ({ accountId, config, filterTerm }) => {
 
       log.ok(MESSAGES.SUCCESS);
     } catch (e) {
-      if (strategy === AUTOMATIC) {
-        log.fatal(`Could not save the new settings to automatically read new releases of "${config.url}"`, e);
-      } else {
-        log.fatal(`Could not save the new settings to read new releases of "${config.url}" from "${strategy}"`, e);
-      }
+      log.fatal(`Could not change release workflow`, e);
     }
   };
 
@@ -163,11 +159,7 @@ const RepoConfig = ({ accountId, config, filterTerm }) => {
       log.ok(MESSAGES.SUCCESS);
     } catch (e) {
       onError && onError();
-      if (strategy === AUTOMATIC) {
-        log.fatal(`Could not configure automatic releases of "${config.url}"`, e);
-      } else {
-        log.fatal(`Could not save the new pattern to read new releases of "${config.url}" from "${strategy}"`, e);
-      }
+      log.fatal(`Could not configure release workflow`, e);
     }
   };
 

--- a/src/js/services/logger.jsx
+++ b/src/js/services/logger.jsx
@@ -6,20 +6,28 @@ export default {
         console.log(...msgs);
     },
     info: (...msgs) => {
-        toast.info(<Msgs msgs={msgs} />);
+        toast.info(<Msgs msgs={msgs} />, {
+            autoClose: 5000,
+        });
     },
     ok: (...msgs) => {
-        toast.success(<Msgs msgs={msgs} />);
+        toast.success(<Msgs msgs={msgs} />, {
+            autoClose: 1000,
+        });
     },
     error: (...msgs) => {
         console.error(...msgs);
-        toast.error(<Msgs msgs={msgs} />);
+        toast.error(<Msgs msgs={msgs} />, {
+            autoClose: 5000,
+        });
     },
     fatal: (...msgs) => {
         // TODO(dpordomingo): this kind of errors are not caused by user input, so we should send them to sentry, for example.
         // We could also use the chat to send feedback in real time.
         console.error(...msgs);
-        toast.error(<Msgs msgs={msgs} />);
+        toast.error(<Msgs msgs={msgs} />, {
+            autoClose: 5000,
+        });
     },
 };
 

--- a/src/js/services/logger.jsx
+++ b/src/js/services/logger.jsx
@@ -47,15 +47,14 @@ const extractParts = item => {
 
     if (item.body?.title && item.body?.type) {
         // errors returned by the API, as proper HTTP response (see API errors schema)
-        const parts = [];
-        parts.push(item.body.detail);
-        parts.push(`${item.body.title}. ${item.body.type}`);
-        return parts.filter(v => !!v);
+        return [item.body.detail || item.body.title];
     }
 
     if (item.error) {
-        // e.g. when JSON response could not be parsed (e.g. API returning NaN for old go-git '/filter/pull_requests')
-        let parts = errorParts(item.error);
+        // e.g. when JSON response could not be parsed
+        // e.g. Request has been terminated (connectivity loss; no HTTP response)
+        let parts = errorParts(item.error)
+            .map(s => s.includes('Request has been terminated') ? 'Connectivity loss' : s);
         return parts.length ? parts : ['Unhandled error'];
     }
 

--- a/src/sass/components/_alerts.scss
+++ b/src/sass/components/_alerts.scss
@@ -14,3 +14,53 @@
         }
     }
 }
+
+// Toastify Alerts
+
+.Toastify__toast {
+    border: 1px solid;
+    border-radius: 4px;
+    box-shadow: none;
+    font-family: "Cerebri", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    min-width: 150px;
+    min-height: 42px;
+    padding: 12px;
+
+    &--dark {
+        background-color: $color-dark;
+        border-color: $color-dark;
+        color: $white;
+    }
+
+    &--default {
+        background-color: $white;
+        border-color: $at-border-color;
+        color: $color-secondary;
+        box-shadow: 0 0 4px rgba(0,0,0,0.1);
+    }
+
+    &--info {
+        background-color: lighten($color-blue,40%);
+        color: $color-blue;
+    }
+
+    &--success {
+        background-color: lighten($color-turquoise,45%);
+        color: $color-turquoise;
+    }
+
+    &--warning {
+        background-color: lighten($color-light-orange,35%);
+        color: $color-light-orange;
+    }
+
+    &--error {
+        background-color: lighten($color-red,35%);
+        color: $color-red;
+    }
+
+    &-body {
+        margin: 0 !important;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
This is based on the issue [#ENG-838](https://athenianco.atlassian.net/browse/ENG-838), and it adds new styles and behavior for the `Toastify` alerts and a new copy for the success cases to simplify the messaging. 

It is still missing the new copy for the errors as it had several conditions that I wasn't sure about.


![image](https://user-images.githubusercontent.com/14981468/82358559-f8a0f200-9a06-11ea-8b90-0c759fec05cb.png)


![image](https://user-images.githubusercontent.com/14981468/82358479-ddce7d80-9a06-11ea-850a-8134b1a41b14.png)

