### PR TITLE
Let the user filter by repo name

### DIFF
--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -235,7 +235,7 @@ const draw = (stage, data) => {
               </div>
             `;
           case 'filter':
-            return row.title + ` number:${row.number} ` + (row.authors.map(user => `author:${github.userName(user)}`).join(' '));
+            return `${row.title} ${row.repo} number:${row.number} ` + (row.authors.map(user => `author:${github.userName(user)}`).join(' '));
           case 'type':
           case 'sort':
           default:


### PR DESCRIPTION
fix [[ENG-888]] Allow to search PRs by repo name in the tables
caused by https://github.com/athenianco/athenian-webapp/pull/344

[ENG-888]: https://athenianco.atlassian.net/browse/ENG-888