### PR TITLE
Ratio flow

### DIFF
--- a/src/js/components/insights/charts/library/TimeSeries.jsx
+++ b/src/js/components/insights/charts/library/TimeSeries.jsx
@@ -66,6 +66,8 @@ export const computeTickValues = (formattedData, maxNumberOfTicks) => {
     }
 };
 
+const filterEmptyValues = v => v !== null;
+
 const TimeSeries = ({ title, data, extra }) => {
     const [currentHover, setCurrentHover] = useState(null);
 
@@ -80,6 +82,8 @@ const TimeSeries = ({ title, data, extra }) => {
               y: v[extra.axisKeys.y]
           }))
           .value();
+
+    const dataPoints = formattedData.filter(v => (extra.filterValuesFn || filterEmptyValues)(v.y));
 
     const tickValues = computeTickValues(formattedData, extra.maxNumberOfTicks);
 
@@ -116,13 +120,13 @@ const TimeSeries = ({ title, data, extra }) => {
           <YAxis />
           {extra.axisLabels && extra.axisLabels.y && buildChartLabel(extra.axisLabels.y, 'y')}
 
-          <LineSeries data={formattedData} color={extra.color} animation="stiff" />
+          <LineSeries data={dataPoints} color={extra.color} animation="stiff" />
           <MarkSeries
             sizeRange={[5, 15]}
             stroke={extra.color}
             fill="white"
             strokeWidth={3}
-            data={formattedData}
+            data={dataPoints}
             animation="stiff"
             onValueMouseOver={(datapoint, event) => onValueChange(datapoint, "mouseover", currentHover, setCurrentHover)}
             onValueMouseOut={(datapoint, event) => onValueReset(datapoint, "mouseout", currentHover, setCurrentHover)}

--- a/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
+++ b/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
@@ -30,11 +30,18 @@ const pullRequestRatioFlow = {
                     prsMetrics.closed,
                 )
             )
-                .map(v => ({
-                    day: v[0].date,
-                    value: v[0].value,
-                    legend: [v[1].value, v[2].value]
-                }))
+                .map(v => {
+                    const ratio = v[0].value;
+                    const opened = v[1].value;
+                    const closed = v[2].value;
+                    const trickedOpened = opened !== null || closed !== null ? opened + 1 : null;
+                    const trickedClosed = opened !== null || closed !== null ? closed + 1 : null;
+                    return {
+                        day: v[0].date,
+                        value: ratio,
+                        legend: {ratio, opened: trickedOpened, closed: trickedClosed},
+                    }
+                })
                 .value(),
             KPIsData: {
                 avgRatioFlow: data.global['prs-metrics.values'].all['flow-ratio'],
@@ -83,8 +90,8 @@ const pullRequestRatioFlow = {
                             color: '#41CED3',
                             tooltip: {
                                 renderBigFn: v => <BigText
-                                    content={`${v.legend[0] || 0}/${v.legend[1] || 0}`}
-                                    extra={number.round((v.legend[0] || 1) / (v.legend[1] || 1), 1)}
+                                    content={`${v.legend.opened }/${v.legend.closed}`}
+                                    extra={number.round(v.legend.ratio, 1)}
                                 />,
                             },
                         },

--- a/src/js/pages/pipeline/Body.jsx
+++ b/src/js/pages/pipeline/Body.jsx
@@ -100,7 +100,7 @@ export default ({ children }) => {
           .reduce((result, v) => {
             _(allMetrics).forEach((m, i) => {
               (result[m] || (result[m] = [])).push(
-                { date: v.date, value: v.values[i] || 0 }
+                { date: v.date, value: v.values[i] }
               )
             })
               


### PR DESCRIPTION
fix [[ENG-898]] Finalize the PR ratio flow fix on the Frontend
partially addresses [[ENG-537]] Ignore points for days of the charts when we don't have data

null values were also removed :point_down: 
![image](https://user-images.githubusercontent.com/2437584/82526842-46b41380-9b35-11ea-9f77-c944c78a9615.png)

before this PR :point_down: 
![image](https://user-images.githubusercontent.com/2437584/82524441-3862f900-9b2f-11ea-9254-fc16beae8c2a.png)




[ENG-898]: https://athenianco.atlassian.net/browse/ENG-898
[ENG-537]: https://athenianco.atlassian.net/browse/ENG-537