### PR TITLE
Restore default Branch and Tag patterns when using Automatic strategy

### DIFF
--- a/src/js/pages/settings/Releases.jsx
+++ b/src/js/pages/settings/Releases.jsx
@@ -111,9 +111,21 @@ const RepoConfig = ({ accountId, config, filterTerm }) => {
       if (!apiReady) {
         throw new Error('Could not obtain an API client');
       };
-      await saveRepoSettings(api, accountId, [config.url], strategy, branchState, tagState);
+
+      await saveRepoSettings(
+        api,
+        accountId,
+        [config.url],
+        strategy,
+        strategy === AUTOMATIC ? defaultPatterns[BRANCH] : branchState,
+        strategy === AUTOMATIC ? defaultPatterns[TAG] : tagState
+      );
+
       setMatchState(strategy);
+
       if (strategy === AUTOMATIC) {
+        setBranchState(defaultPatterns[BRANCH]);
+        setTagsState(defaultPatterns[TAG]);
         log.ok(`Releases from "${config.url}" will be guessed automatically from tags or default branch if there are no tags available`);
       } else {
         log.ok(`Releases from "${config.url}" will be read from "${strategy}"`);


### PR DESCRIPTION
solves [[ENG-901]] Reset the branch and tag patterns when you select “Automatic“ in the release settings.

When the user selects the `Automatic` strategy, whatever patterns were used for tags and branches are restored to its default values.

[ENG-901]: https://athenianco.atlassian.net/browse/ENG-901