### PR TITLE
Remove null values from Thumbnails and WaitTime1stReview

### DIFF
--- a/src/js/components/charts/CleanAreaChart.jsx
+++ b/src/js/components/charts/CleanAreaChart.jsx
@@ -6,6 +6,8 @@ import { hexToRGBA } from 'js/services/colors';
 
 import { extent } from 'd3-array';
 
+const filterEmptyValues = v => v !== null;
+
 export default ({ fill, stroke, data }) => {
 
   const key = () => Math.random().toString(36).substring(2, 15);
@@ -32,13 +34,15 @@ export default ({ fill, stroke, data }) => {
   const [yMin, yMax] = extent(data, d => d.y);
   const newYMin = (yMin || 0) - ((yMax || 0) - (yMin || 0)) * .2
 
+  const dataPoints = data.filter(v => filterEmptyValues(v.y));
+
   return (
     <FlexibleXYPlot yDomain={[newYMin, yMax]} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
       <GradientDefs>
         {gradients}
       </GradientDefs>
-      <LineSeries data={data} color={strokeColor} animation="stiff" />
-      <AreaSeries data={data} stroke="none" fill={fillColor} animation="stiff" />
+      <LineSeries data={dataPoints} color={strokeColor} animation="stiff" />
+      <AreaSeries data={dataPoints} stroke="none" fill={fillColor} animation="stiff" />
     </FlexibleXYPlot>
   );
 };

--- a/src/js/components/charts/Tooltip.jsx
+++ b/src/js/components/charts/Tooltip.jsx
@@ -31,15 +31,14 @@ export default ({value, ...props}) => {
     );
 };
 
-export const DateBigNumber = ({ value, renderBigFn = v => <BigText content={number.round(v.y)} />, ...props }) => {
-    if (!value) return null;
-
+export const DateBigNumber = ({ value, dataPoint, renderBigFn = v => <BigText content={number.round(v.y)} />, ...props }) => {
+    if (!value || !dataPoint) return null;
     return (
         <Hint {...props} value={value}>
             <TooltipContainer left>
                 <Group>
-                    <AltTitle content={<DateWeekDayMonth date={moment(value.x)} uppercase />} />
-                    {renderBigFn(value)}
+                    <AltTitle content={<DateWeekDayMonth date={moment(dataPoint.x)} uppercase />} />
+                    {renderBigFn(dataPoint)}
                 </Group>
             </TooltipContainer>
         </Hint>

--- a/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
+++ b/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
@@ -38,11 +38,11 @@ const waitTimeFirstReview = {
 
         return {
             chartData: _(data.global['prs-metrics.values'].custom['wait-first-review'])
-                .map(v => ({day: v.date, value: v.value / 3600}))
+                .map(v => ({day: v.date, value: v.value === null ? null : v.value * 1000}))
                 .value(),
             KPIsData: {
                 avgWaitingTime: {
-                    value: Math.round(currWaitFirstReview / 3600),
+                    value: currWaitFirstReview * 1000,
                     variation: waitFirstReviewVariation
                 },
                 overallProportion: {
@@ -68,6 +68,7 @@ const waitTimeFirstReview = {
                         component: TimeSeries,
                         params: {
                             data: computed.chartData,
+                            timeMode: true,
                             extra: {
                                 average: {
                                     value: computed.KPIsData.avgWaitingTime.value,
@@ -83,7 +84,7 @@ const waitTimeFirstReview = {
                                 },
                                 color: '#41CED3',
                                 tooltip: {
-                                    renderBigFn: v => <BigText content={dateTime.human(v.y * 60 * 60 * 1000)} />,
+                                    renderBigFn: v => <BigText content={dateTime.human(v.y)} />,
                                 },
                             }
                         }
@@ -94,13 +95,9 @@ const waitTimeFirstReview = {
                             subtitle: {text: 'For 1st Review'},
                             component: SimpleKPI,
                             params: {
-                                value: computed.KPIsData.avgWaitingTime.value,
+                                value: dateTime.bestTimeUnit(computed.KPIsData.avgWaitingTime.value, 0),
                                 variation: computed.KPIsData.avgWaitingTime.variation,
                                 variationMeaning: NEGATIVE_IS_BETTER,
-                                unit: {
-                                    singular: 'hour',
-                                    plural: 'hours'
-                                }
                             }
                         },
                         {

--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -15,7 +15,7 @@ import { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 
 import { pipelineStagesConf } from 'js/pages/pipeline/Pipeline';
 
-import { dateTime, number, getBestTimeUnit } from 'js/services/format';
+import { dateTime, number } from 'js/services/format';
 import { hexToRGBA } from 'js/services/colors';
 import { palette } from 'js/res/palette';
 
@@ -121,35 +121,25 @@ export const OverviewSummaryMetrics = ({name, metric}) => {
     );
 };
 
-
-const getBestFitDurationUnit = data => {
-    const maxValue = _(data)
-        .map(v => v.y * 1000)
-        .max();
-
-    return getBestTimeUnit(maxValue);
-};
-
 const SummaryMetrics = ({ data, stage, KPIComponent, status, chartConfig }) => {
-    let [conversionValue, durationUnit] = [];
     let extra = {};
     let timeseries = [];
 
     if (status === READY) {
-      [conversionValue, durationUnit] = getBestFitDurationUnit(data.timeseries);
-
       extra = {
         color: chartConfig.color,
         fillColor: hexToRGBA(chartConfig.color, .2),
         height: chartConfig.height,
         axisKeys: {x: 'x', y: 'y'},
-        axisTickFormats: {y: s => `${s} ${durationUnit}`},
         maxNumberOfTicks: 6,
-        average: {value: data.average * 1000 / conversionValue, color: palette.schemes.trend},
-        tooltip: {renderBigFn: v => <BigText content={dateTime.bestTimeUnit(v.y * conversionValue)} />}
+        average: {value: data.average * 1000, color: palette.schemes.trend},
+        tooltip: {renderBigFn: v => <BigText content={dateTime.human(v.y, 1)} />}
       };
 
-      timeseries = data.timeseries.map(v => ({x: v.x, y: v.y === null ? null : v.y * 1000 / conversionValue}));
+      timeseries = data.timeseries.map(v => ({
+        ...v,
+        y: v.y === null ? null : v.y * 1000
+      }));
     }
 
     return (
@@ -174,7 +164,7 @@ const SummaryMetrics = ({ data, stage, KPIComponent, status, chartConfig }) => {
               {
                   status === READY &&
                       <div className="col-8 align-self-center">
-                          <TimeSeries data={timeseries} extra={extra} />
+                          <TimeSeries data={timeseries} extra={extra} timeMode={true} />
                       </div>
               }
             </div>

--- a/src/js/services/format.js
+++ b/src/js/services/format.js
@@ -60,7 +60,7 @@ const bestTimeUnit = (milliseconds, decimals = 2) => {
  * @param {int} milliseconds
  * @return {string}
  */
-const human = milliseconds => {
+const human = (milliseconds, decimals = 0) => {
     if (isNaN(milliseconds)) {
         return '';
     }
@@ -72,17 +72,17 @@ const human = milliseconds => {
     } else if (milliseconds <= 1.75 * MINUTE) {
         return '~1 min';
     } else if (milliseconds <= 1.75 * HOUR) {
-        return Math.round(milliseconds / MINUTE) + ' mins';
+        return roundDecimals(milliseconds / MINUTE, decimals) + ' mins';
     } else if (milliseconds <= 1.75 * DAY) {
-        return Math.round(milliseconds / HOUR) + ' hours';
+        return roundDecimals(milliseconds / HOUR, decimals) + ' hours';
     } else if (milliseconds <= 12 * DAY) {
-        return Math.round(milliseconds / DAY) + ' days';
+        return roundDecimals(milliseconds / DAY, decimals) + ' days';
     } else if (milliseconds <= 8 * WEEK) {
-        return Math.round(milliseconds / WEEK) + ' weeks';
+        return roundDecimals(milliseconds / WEEK, decimals) + ' weeks';
     } else if (milliseconds <= 22 * MONTH) {
-        return Math.round(milliseconds / MONTH) + ' months';
+        return roundDecimals(milliseconds / MONTH, decimals) + ' months';
     } else if (milliseconds <= 5 * YEAR) {
-        return Math.round(milliseconds / YEAR) + ' years';
+        return roundDecimals(milliseconds / YEAR, decimals) + ' years';
     }
 
     return '>5 years';

--- a/src/js/services/format.js
+++ b/src/js/services/format.js
@@ -16,6 +16,14 @@ const YEAR = 365 * DAY;
 
 const roundDecimals = (num, decimals) => Math.round((num + Number.EPSILON) * 10**decimals) / 10**decimals;
 
+export const getBestFitDurationUnit = data => {
+    const maxValue = _(data)
+        .map(v => v.y)
+        .max();
+
+    return getBestTimeUnit(maxValue);
+};
+
 export const getBestTimeUnit = (milliseconds) => {
     const units = [
         [SECOND, 'secs'],


### PR DESCRIPTION
closes [[ENG-537]] Ignore points for days of the charts when we don't have data

Remove null values from Thumbnails and WaitTime1stReview

This PR also:
- 1dd15dc Let `dateTime.human` return decimals when rounding times
- 6e5c388 Make `TimeSeries` chart to work also with time durations in `y-axis`, just passing `timeMode={true}` property. This will avoid us to make conventions between time durations and best unit outside the chart, because that conversion will be done inside the `TimeSeries` chart.



![image](https://user-images.githubusercontent.com/2437584/82695811-2041c580-9c66-11ea-9704-ec82a1c86406.png)


[ENG-537]: https://athenianco.atlassian.net/browse/ENG-537