### PR TITLE
Exclude WIP PRs from PullRequestSize chart

### DIFF
--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -25,7 +25,7 @@ const pullRequestSize = {
 
                     // TODO(dpordomingo): This Chart shows PRs in two groups: waiting for review or not.
                     //   Grouping criteria should be having review_happened or approve_happened or changes_request_happened or merge_happened or being closed.
-                    //   But API since the tooltip also needs to show the time waiting for being reviewed, and the events
+                    //   But since the tooltip also needs to show the time waiting for being reviewed, and the events
                     //   above do not expose it, we can only differentiate between being review-complete, or not.
                     const reviewed = pr.completedStages.includes(PR_STAGE.REVIEW);
 

--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -13,6 +13,7 @@ const pullRequestSize = {
         const { prs, users } = data.global['prs'];
         return {
             chartData: _(prs)
+                .filter(pr => pr.completedStages.includes(PR_STAGE.WIP))
                 .map(pr => {
                     let endTime;
                     if (pr.closed instanceof Date && !isNaN(pr.closed)) {

--- a/src/js/components/insights/stages/work-in-progress/mostActiveDevs.jsx
+++ b/src/js/components/insights/stages/work-in-progress/mostActiveDevs.jsx
@@ -8,6 +8,8 @@ import { github, number } from 'js/services/format';
 
 const mostActiveDevs = {
     plumber: (data) => {
+        // TODO (dpordomingo): This chart should use /metrics/developers endpoint instead of PRs from /filter/pull_requests
+        // which could be eventually paginated because it's too heavy
         const prs = data.global.prs;
         const avatarMapping = github.userImageIndex(prs.users);
         return {


### PR DESCRIPTION
addresses [[ENG-903]] Exclude PRs not having the reviewing property from the PR size chart

As explained in the issue desc, we still not know when a PR was reviewed, so PullRequestSize chart is still about **approved** vs **not approved** PRs and the time **waiting for approval**:
- Approved PRs (green)
&rarr; the tooltip shows `(approved || merged) - (review_requested || created)`
- Not Approved PRs (orange)
&rarr; the tooltip shows `now() - (review_requested || created)`

see source code:
```js
// green if in MERGE, RELEASE or DONE; orange if still in REVIEW (not yet approved)
const reviewed = pr.completedStages.includes(PR_STAGE.REVIEW);
// tooltip
const timeWaiting = dateTime.interval(
    pr.review_requested || pr.created,
    pr.approved || endTime
);
```

[ENG-903]: https://athenianco.atlassian.net/browse/ENG-903