### PR TITLE
Fixing the search box on the Add new team dropdown

### DIFF
--- a/src/js/pages/settings/Team.jsx
+++ b/src/js/pages/settings/Team.jsx
@@ -187,8 +187,8 @@ const AddTeam = ({ onSave, developers }) => {
               autoComplete='off'
             />
           </div>
-          <div style={{ marginBottom: 8 }}>
-            <span style={{ color: '#121343', fontSize: '12px' }}>Add users to your team:</span>
+          <div className="mt-4 mb-3">
+            <span className="text-dark h6">Add users to your team:</span>
           </div>
           <Select
             options={developers}
@@ -212,6 +212,8 @@ const AddTeam = ({ onSave, developers }) => {
               control: styles => ({
                 ...styles,
                 margin: 14,
+                minHeight: 30,
+                height: 30,
                 borderRadius: 0,
                 border: 0
               }),

--- a/src/sass/components/_dropdowns.scss
+++ b/src/sass/components/_dropdowns.scss
@@ -74,6 +74,7 @@
 
 .dropdown-menu {
     min-width: 14rem !important;
+    font-weight: 400;
 
     .dropdown-item {
         font-size: 1.2rem;

--- a/src/sass/components/_forms.scss
+++ b/src/sass/components/_forms.scss
@@ -2,6 +2,7 @@
     border-radius: 0 !important;
     color: $dark !important;
     height: 3.2rem !important;
+    font-weight: 300;
 }
 
 .input-group {


### PR DESCRIPTION
This fixes the issue [#ENG-956](https://athenianco.atlassian.net/browse/ENG-956). It fix the search box height on the 'Add new team' dropdown. I also added some minor style fixes on the dropdown:

![image](https://user-images.githubusercontent.com/14981468/82886836-64271a00-9f47-11ea-9304-f61e7b361fc3.png)


Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>