### PR TITLE
Improving filters consistency and styles

### DIFF
--- a/src/js/components/ui/filters/MultiSelect/CustomStyles.jsx
+++ b/src/js/components/ui/filters/MultiSelect/CustomStyles.jsx
@@ -53,7 +53,7 @@ export const customStyles = {
       gridColumnGap: 4,
       padding: `${option && option.options ? '6px 12px 6px 24px' : '6px 12px'}`,
       ':active': {
-        backgroundColor: '#FF7427',
+        backgroundColor: '#FFA008',
         color: '#fff',
       }
     }

--- a/src/js/components/ui/filters/MultiSelect/CustomStyles.jsx
+++ b/src/js/components/ui/filters/MultiSelect/CustomStyles.jsx
@@ -24,7 +24,7 @@ export const customStyles = {
     position: 'absolute',
     background: '#e7e7ec',
     border: '1px solid #E7E7EC',
-    top: 'calc(100% + 8px)'
+    top: 'calc(100% + 8px)',
   }),
   valueContainer: styles => ({
     ...styles,
@@ -51,17 +51,28 @@ export const customStyles = {
       borderBottom: '1px solid #D6DBE4',
       gridTemplateColumns: '20px calc(100% - 16px)',
       gridColumnGap: 4,
-      padding: `${option && option.options ? '6px 12px 6px 24px' : '6px 12px'}`
+      padding: `${option && option.options ? '6px 12px 6px 24px' : '6px 12px'}`,
+      ':active': {
+        backgroundColor: '#FF7427',
+        color: '#fff',
+      }
     }
   },
-  control: styles => ({
-    ...styles,
+  control: (base, state) => ({
+    ...base,
     borderRadius: 0,
-    borderColor: '#E7E7EC',
+    borderColor: state.isFocused
+        ? '#ffd188'
+        : '#e7e7ec',
+    boxShadow: state.isFocused ? '0 0 0 0.2rem rgba(255, 160, 8, 0.25)' : 0,
     paddingRight: '8px',
-    margin: '10px 10px 1px',
+    margin: '10px 10px 4px',
     minHeight: 30,
-    height: 30
+    height: 30,
+    '&:hover': {
+      boxShadow: '0 0 0 0.2rem rgba(255, 160, 8, 0.25)',
+      borderColor: '#ffd188',
+    }
   }),
   menu: styles => ({
     ...styles,
@@ -107,7 +118,7 @@ export const customStyles = {
   })
 }
 
-// Color ranges used to generate new colors based on strings 
+// Color ranges used to generate new colors based on strings
 // for teams select
 export const brandColors = [
   [210.6, 85, 50.2],

--- a/src/js/pages/settings/Team.jsx
+++ b/src/js/pages/settings/Team.jsx
@@ -198,11 +198,18 @@ const AddTeam = ({ onSave, developers }) => {
                 background: '#E7E7EC',
                 paddingTop: 2
               }),
-              control: styles => ({
-                ...styles,
+              control: (base, state) => ({
+                ...base,
                 margin: 14,
                 borderRadius: 0,
-                border: 0
+                borderColor: state.isFocused
+                    ? '#ffd188'
+                    : '#e7e7ec',
+                boxShadow: state.isFocused ? '0 0 0 0.2rem rgba(255, 160, 8, 0.25)' : 0,
+                '&:hover': {
+                  boxShadow: '0 0 0 0.2rem rgba(255, 160, 8, 0.25)',
+                  borderColor: '#ffd188',
+                }
               }),
               menu: styles => ({
                 ...styles,

--- a/src/sass/components/_datepicker.scss
+++ b/src/sass/components/_datepicker.scss
@@ -44,6 +44,14 @@
     margin-right: 1rem;
 }
 
+.DateRangePickerInput__withBorder {
+    transition: ease-in-out border 0.3s;
+
+    &:hover {
+        border-color: #c0c1ce;
+    }
+}
+
 .DateRangePickerInput_calendarIcon {
     margin-left: 0;
     margin-right: 0;

--- a/src/sass/components/_filters.scss
+++ b/src/sass/components/_filters.scss
@@ -32,10 +32,10 @@
   transition: ease-in-out border 0.3s;
 
   & svg {
-    fill: hsl(0,0%,70%);
+    fill: #c0c1ce;
   }
   &:hover, &.open {
-    border-color: hsl(0,0%,70%);
+    border-color: #c0c1ce;
     & svg {
       fill: $color-secondary;
     }
@@ -92,6 +92,10 @@
 
   &-option-user {
     color: $color-secondary;
+
+    .filter-dropdown-option:active & {
+      color: rgba($white,0.8);
+    }
   }
   &-option-prefix {
     @include filter-avatar();


### PR DESCRIPTION
This is related to the issue #ENG-958 and it adds some styling to the filters to make them consistent:

- Make the border color of the dev and repo filter on hover lighter (same color as the status filter on hover)

![image](https://user-images.githubusercontent.com/14981468/82898098-fbe13400-9f58-11ea-9cb2-96ec3555c455.png)

- Add the border color change on hover over the daterange picker box

![image](https://user-images.githubusercontent.com/14981468/82898210-28954b80-9f59-11ea-84fc-f602f78f824b.png)

- Style the `:active` state on the filters

![image](https://user-images.githubusercontent.com/14981468/82898324-5bd7da80-9f59-11ea-82ca-f26269d1cde0.png)

- Make the :focus on the search boxes consistent with the rest of the webapp inputs

![image](https://user-images.githubusercontent.com/14981468/82898348-6abe8d00-9f59-11ea-9ed1-2f8aa490cdda.png)
