### PR TITLE
Fix main summary metric size

### DIFF
--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -29,7 +29,7 @@ html {
 }
 
 .big-number.text-xl {
-    font-size: 1.7rem;
+    font-size: 3rem;
 }
 
 .fa {


### PR DESCRIPTION
This fixes the issue [#ENG-969](https://athenianco.atlassian.net/browse/ENG-963). If fixes the size of the main summary metrics on the pipeline charts to match the prototypes:

![image](https://user-images.githubusercontent.com/14981468/82909841-196ac980-9f6a-11ea-9388-8d6db13cd391.png)

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>