### PR TITLE
fix(ENG-972): Add New Team button disabled even with teamName and teamMember

### DIFF
--- a/src/js/pages/settings/Team.jsx
+++ b/src/js/pages/settings/Team.jsx
@@ -212,7 +212,7 @@ const TeamForm = ({btnText, onSave, developers, team, options}) => {
   const onChange = ev => {
     const { target: { value } } = ev
     setTeamName(value)
-    setTeamMembers([])
+    setTeamMembers(teamMembers)
   }
 
   const saveTeam = () => {
@@ -229,7 +229,7 @@ const TeamForm = ({btnText, onSave, developers, team, options}) => {
   const applyDisabled = (opts.nameChangeEnabled && opts.membersChangeEnabled) ?
         (!teamName.length || !teamMembers.length) :
         (opts.nameChangeEnabled ? !teamName.length : !teamMembers.length)
-
+  
   return (
     <>
       <button


### PR DESCRIPTION
Closes: https://athenianco.atlassian.net/browse/ENG-972
If we create a team in a different order the button stays disabled.
- Pick team members first then add a team name, it'll keep the button disabled