### PR TITLE
Use only active days for CreatedPRs chart average KPI

### DIFF
--- a/src/js/components/insights/stages/work-in-progress/createdPrs.jsx
+++ b/src/js/components/insights/stages/work-in-progress/createdPrs.jsx
@@ -24,7 +24,7 @@ export default {
         const openedMetrics = data.global['prs-metrics.values'].custom.opened;
         const dayCreations = data.dayCreations.calculated[0].values;
         const createdPRs = data.global['prs-metrics.values'].all['opened'] || 0;
-        const days = dayCreations.length || 1;
+        const days = _(dayCreations).reduce( (acc, day) => day.values[0] ? acc + 1 : acc, 0) || 1;
         const avgCreatedPRs = createdPRs / days;
 
         return {
@@ -69,8 +69,8 @@ export default {
                 },
                 kpis: [
                     {
-                        title: {text: 'Average Pull Request', bold: true},
-                        subtitle: {text: 'Creation'},
+                        title: {text: 'Average Number of Pull Requests', bold: true},
+                        subtitle: {text: 'Created per Day'},
                         component: SimpleKPI,
                         params: {
                             value: number.fixed(computed.KPIsData.avgCreatedPRs, 2)

--- a/src/js/components/layout/Footer.jsx
+++ b/src/js/components/layout/Footer.jsx
@@ -17,7 +17,7 @@ export default () => {
   return <footer className="sticky-footer bg-white border-top">
     <div className="container my-auto">
       <div className="text-center my-auto">
-        <span>Copyright &copy; Athenian.co 2020</span><br/><span class="text-bright small">{versions}</span>
+        <span>Copyright &copy; Athenian.co 2020</span><br/><span className="text-bright small">{versions}</span>
       </div>
     </div>
   </footer>

--- a/src/js/pages/Settings.jsx
+++ b/src/js/pages/Settings.jsx
@@ -11,7 +11,6 @@ import welcome from 'images/settings-welcome.svg';
 import Page from 'js/pages/templates/Page';
 
 import { useUserContext } from 'js/context/User';
-import { isNotProd } from 'js/components/development';
 
 export const getOrg = user => {
   const orgName = _(user.defaultReposet.repos)


### PR DESCRIPTION
fix [[ENG-761]] WIP: Pull Requests created through time

This will discard days when no PR was created when calculating the average

## notice
The Chart is still hidden at Prod; let me know if we should enable it, or feel free to PR it on your own.

[ENG-761]: https://athenianco.atlassian.net/browse/ENG-761