### PR TITLE
Pr size improvements

### DIFF
--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -24,17 +24,13 @@ const pullRequestSize = {
                         endTime = moment();
                     }
 
-                    // TODO(dpordomingo): This Chart shows PRs in two groups: waiting for review or not.
-                    //   Grouping criteria should be having review_happened or approve_happened or changes_request_happened or merge_happened or being closed.
-                    //   But since the tooltip also needs to show the time waiting for being reviewed, and the events
-                    //   above do not expose it, we can only differentiate between being review-complete, or not.
-                    const reviewed = pr.completedStages.includes(PR_STAGE.REVIEW);
+                    const reviewed = !!pr.first_review || !!pr.closed;
 
                     const authorFullName = pr.authors[0];
                     const author = authorFullName ? github.userName(authorFullName) : 'none';
                     const timeWaiting = dateTime.interval(
                         pr.review_requested || pr.created,
-                        pr.approved || endTime
+                        pr.first_review || endTime
                     );
                     const tooltip = {
                         number: pr.number,

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -111,13 +111,6 @@ export default pr => {
     commentersReviewers,
     organization: github.repoOrg(pr.repository),
     repo: github.repoName(pr.repository),
-    created: new Date(pr.created),
-    updated: new Date(pr.updated),
-    closed: pr.closed && new Date(pr.closed),
-    review_requested: pr.review_requested && new Date(pr.review_requested),
-    approved: pr.approved && new Date(pr.approved),
-    merged: pr.merged && new Date(pr.merged),
-    released: pr.released && new Date(pr.released),
     stage_timings,
   };
 };


### PR DESCRIPTION
solves [[ENG-938]] PR Size chart not seeing approval event from the future
solves [[ENG-942]] Remove the approx of the PR Size chart relying on the approval instead of the 1st review

Use `first_review` new PR property to calculate the time between `review_requested` or `created` event and that time.

Also, this PR stops converting PR date properties into `Date` types because it's already done by OpenApi client generator (see d2066f4)


[ENG-938]: https://athenianco.atlassian.net/browse/ENG-938
[ENG-942]: https://athenianco.atlassian.net/browse/ENG-942