### PR TITLE
fix(ENG-887): Avoid going back to top when clicking on a filter option

### DIFF
--- a/src/js/components/ui/filters/MultiSelect/CustomComponents.jsx
+++ b/src/js/components/ui/filters/MultiSelect/CustomComponents.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react'
-import { customStyles as styles, brandColors } from './CustomStyles'
+import React, { useState, useEffect } from 'react'
+import { brandColors } from './CustomStyles'
 import { FilterFooter } from '../FilterFooter'
 import { StatusIndicator, LOADING } from 'js/components/ui/Spinner'
 import { ReactComponent as DropdownIndicator } from './IconDropdownIndicator.svg'
@@ -34,79 +34,36 @@ const stringToColour = str => {
 
 /**
  * CustomComponents used to override react-select components
- * @param {function} children
- * @param {string} label
- * @param {boolean} isLoading
- * @param {function} onApply
- * @param {Array} value
+ * @param {string} props.label
+ * @param {boolean} props.isLoading
+ * @param {boolean} props.isOpen
+ * @param {number} props.count
+ * @param {function} props.setMenuOpen 
  */
 export const Dropdown = ({
-  children,
   label,
   isLoading,
-  onApply,
-  value,
-  onClose
+  isOpen,
+  count,
+  setMenuOpen,
+  // onClose
 }) => {
-  const [isMenuOpen, setMenuState] = useState(false)
-  const ref = useRef(null)
-
-  const setMenuOpen = (bool, wasApplied = false) => {
-    setMenuState(bool)
-    if (!bool) {
-      onClose(wasApplied)
-    }
-  }
-
-  const toggle = e => {
-    const menu = ref.current.querySelector('.filter')
-    // if click inside menu, skip toggle
-    if (menu && menu.contains(e.target)) {
-      e.stopPropagation()
-      return
-    }
-    setMenuOpen(!isMenuOpen, false)
-  }
-
-  const closeAll = e => {
-    if (!ref.current.contains(e.target) && ref.current.querySelector('.open')) {
-      setMenuOpen(false, true)
-    }
-  }
-
-  useEffect(() => {
-    window.addEventListener('click', closeAll)
-    return () => {
-      window.removeEventListener('click', closeAll)
-    }
-  }, [closeAll])
-
-  const childrenProps = {
-    menuIsOpen: isMenuOpen,
-    components: {
-      Option,
-      Placeholder,
-      Group,
-      Menu: menu({ setMenuOpen, onApply })
-    },
-    styles,
-    value
+  const close = () => {
+    setMenuOpen(!isOpen)
+    // onClose(false)
   }
 
   return (
-    <div onClick={toggle} ref={ref}>
-      <div className={`${classNames({ open: isMenuOpen })} filter-dropdown align-items-center`}>
-        <div className="d-flex align-items-center">
-          <span className="filter-dropdown-label">{label}</span>
-          {
-            !isLoading ?
-            <StatusIndicator size={5} status={LOADING} margin={0} /> :
-            <span className="filter-dropdown-pill">{value.length}</span>
-          }
-        </div>
-        <DropdownIndicator />
+    <div className={`${classNames({ open: isOpen })} filter-dropdown align-items-center`} onClick={close}>
+      <div className="d-flex align-items-center">
+        <span className="filter-dropdown-label">{label}</span>
+        {
+          !isLoading ?
+          <StatusIndicator size={5} status={LOADING} margin={0} /> :
+          <span className="filter-dropdown-pill">{count}</span>
+        }
       </div>
-      {children(childrenProps)}
+      <DropdownIndicator />
     </div>
   )
 }
@@ -127,6 +84,9 @@ const HeadingIcon = ({ title }) => {
   )
 }
 
+/**
+ * @param {boolean} props.isOpen 
+ */
 const Chevron = ({ isOpen }) => {
   const style = {
     transform: `rotate(${isOpen ? '0deg' : '-90deg'})`
@@ -169,7 +129,7 @@ const GroupHeading = (onCheck, isChecked, isIndeterminate, onToggle, toggled) =>
  * Group
  * @param {*} param0
  */
-const Group = props => {
+export const Group = props => {
   const [isChecked, setChecked] = useState(true)
   const [isIndeterminate, setIndeterminate] = useState(false)
   const [isOpen, setOpen] = useState(false)
@@ -208,13 +168,14 @@ const Group = props => {
 
 /**
  * Checkbox
- * @param {boolean} isChecked
- * @param {boolean} isIndeterminate
+ * @param {boolean} props.isChecked
+ * @param {boolean} props.isIndeterminate
+ * @param {function} props.onClick
  */
 const Checkbox = ({ isChecked, isIndeterminate, onClick }) => {
   const mark = isChecked ? (
     isIndeterminate ?
-      <rect stroke="#24C7CC" stroke-width="1" x="3" y="7.375" width="10" height="1.25" fill="#24C7CC"></rect>
+      <rect stroke="#24C7CC" strokeWidth="1" x="3" y="7.375" width="10" height="1.25" fill="#24C7CC"></rect>
       :
       <polygon fill="#24C7CC" transform="translate(2.000000, 3.000000)" points="4.22898961 6.47146254 1.97497639 4.14922711 0.5 5.65814507 4.22898961 9.5 11.5 2.00891795 10.0354108 0.5"></polygon>
   ) : null
@@ -252,9 +213,7 @@ export const Option = props => {
 }
 
 /**
- * Placeholder,
- * @param {string} label
- * @return {function}
+ * Placeholder
  */
 export const Placeholder = props => {
   const { selectProps: { name } } = props
@@ -283,7 +242,7 @@ const extractOptions = options => {
   return options
 }
 
-export const menu = ({ setMenuOpen, onApply }) => props => {
+export const Menu = (onApply, setMenuOpen) => props => {
   const {
     children,
     clearValue,
@@ -309,8 +268,9 @@ export const menu = ({ setMenuOpen, onApply }) => props => {
   }
 
   const close = wasApplied => {
-    setMenuOpen(false, wasApplied)
+    setMenuOpen(false)
   }
+
   const apply = () => {
     onApply(allValues)
     close(true)

--- a/src/js/components/ui/filters/MultiSelect/index.jsx
+++ b/src/js/components/ui/filters/MultiSelect/index.jsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useState, useRef, useMemo } from 'react'
 import Select from 'react-select'
-import { Dropdown } from './CustomComponents'
+import { Dropdown, Group, Placeholder, Option, Menu as CustomMenu } from './CustomComponents'
+import { customStyles as styles } from './CustomStyles'
+import { useMountEffect } from 'js/hooks'
 
 const formatMessage = message => () => <em>{message}</em>
 
@@ -19,47 +21,90 @@ const defaultProps = {
 const MultiSelect = multiSelectProps => {
   const {
     label,
-    isLoading,
     noDataMsg,
     className,
     name,
     getOptionValue,
     getOptionLabel,
-    options,
     onApply,
-    value,
     onChange,
-    onClose
+    onClose,
+    isLoading,
+    options,
+    value,
   } = multiSelectProps
 
+  const [isMenuOpen, setMenuOpen] = useState(false)
   const noData = formatMessage(noDataMsg)
   const loading= formatMessage('loading...')
+  const ref = useRef()
+
+  const toggle = e => {
+    const menu = ref.current.querySelector('.filter')
+    // if click inside menu, skip toggle
+    if (menu && menu.contains(e.target)) {
+      e.stopPropagation()
+      return
+    }
+    setMenuOpen(!isMenuOpen)
+  }
+
+  const closeAll = e => {
+    if (!ref.current.contains(e.target)) {
+      setMenuOpen(false)
+    }
+  }
+
+  useMountEffect(() => {
+    window.addEventListener('click', closeAll)
+    return () => {
+      window.removeEventListener('click', closeAll)
+    }
+  }, [])
+
+  /**
+   * @param {function} onApply
+   * @param {function} setMenuOpen
+   */
+  const Menu = useMemo(() => CustomMenu(
+    (values) => {
+      onApply(values)
+      // onClose(true)
+    },
+    (wasApplied) => {
+      // onClose(wasApplied)
+      setMenuOpen()
+    }), [onApply])
+
   return (
-    <Dropdown
-      label={label}
-      isLoading={isLoading}
-      onApply={onApply}
-      value={value}
-      onClose={onClose}
-    >
-      {ddProps => (
-        ddProps.menuIsOpen &&
-          <Select
-            autoFocus
-            options={options}
-            className={className}
-            name={name}
-            getOptionLabel={getOptionLabel}
-            getOptionValue={getOptionValue}
-            noOptionsMessage={noData}
-            loadingMessage={loading}
-            onChange={onChange}
-            value={value}
-            {...defaultProps}
-            {...ddProps} // components
-          />
-      )}
-    </Dropdown>
+    <div ref={ref} onClick={toggle}>
+      <Dropdown
+        label={label}
+        isLoading={isLoading}
+        count={value.length}
+        setMenuOpen={setMenuOpen}
+        isOpen={isMenuOpen}
+        onClose={onClose}
+      />
+      {isMenuOpen &&
+        <Select
+          menuIsOpen
+          autoFocus
+          options={options}
+          className={className}
+          name={name}
+          getOptionLabel={getOptionLabel}
+          getOptionValue={getOptionValue}
+          noOptionsMessage={noData}
+          loadingMessage={loading}
+          onChange={onChange}
+          value={value}
+          components= {{ Option, Placeholder, Group, Menu }}
+          styles={styles}
+          {...defaultProps}
+        />
+      }
+    </div>
   )
 }
 

--- a/src/js/pages/pipeline/Filters/index.jsx
+++ b/src/js/pages/pipeline/Filters/index.jsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useRef } from 'react'
+import React, { useReducer, useRef, useCallback } from 'react'
 import moment from 'moment'
 
 import { useAuth0 } from 'js/context/Auth0'
@@ -95,7 +95,7 @@ export default function Filters({ children }) {
     }))
   }
 
-  const onReposApplyChange = async (selectedRepos, dateInterval) => {
+  const onReposApplyChange = useCallback(async (selectedRepos, dateInterval) => {
     dispatchFilter(setReady(false))
     resetData()
   
@@ -119,9 +119,9 @@ export default function Filters({ children }) {
 
     dispatchFilter(setTeams(teams))
     dispatchFilter(setReady(true))
-  }
+  }, [accountID, contextRepos, filterData.dateInterval, resetData, setGlobalData])
 
-  const onContribsApplyChange = async selectedContribs => {
+  const onContribsApplyChange = useCallback(async selectedContribs => {
     dispatchFilter(setReady(false))
     resetData()
     
@@ -137,11 +137,11 @@ export default function Filters({ children }) {
     dispatchFilter(setSelectedContribs(selectedContribs))
     dispatchFilter(setTeams(teams))
     dispatchFilter(setReady(true))
-  }
+  }, [accountID, filterData.repos.data, resetData, setGlobalData])
   
   const reposLabelFormat = repo => (github.repoName(repo) || 'UNKNOWN')
   const getOptionValueRepos = val => val
-  const getOptionValueUsers = val => `${val.name} ${val.login}`
+  const getOptionValueUsers = val => `${val.id} ${val.name} ${val.login}`
 
   const reposOptions = [...filterData.repos.data]
 
@@ -167,17 +167,17 @@ export default function Filters({ children }) {
   )
 
   // revert previous values is close filter without apply
-  const onCloseRepos = applied => {
-    if (!applied) {
-      dispatchFilter(setSelectedRepos([...filterData.repos.applied]))
-    }
-  }
+  // const onCloseRepos = useCallback(applied => {
+  //   if (!applied) {
+  //     dispatchFilter(setSelectedRepos([...filterData.repos.applied]))
+  //   }
+  // }, [filterData.repos.applied])
 
-  const onCloseContribs = applied => {
-    if (!applied) {
-      dispatchFilter(setSelectedContribs([...filterData.contribs.applied]))
-    }
-  }
+  // const onCloseContribs = useCallback(applied => {
+  //   if (!applied) {
+  //     dispatchFilter(setSelectedContribs([...filterData.contribs.applied]))
+  //   }
+  // }, [filterData.contribs.applied])
 
   return (
     <FiltersContext
@@ -200,7 +200,7 @@ export default function Filters({ children }) {
             onApply={onReposApplyChange}
             onChange={onSelectRepo}
             value={reposValue}
-            onClose={onCloseRepos}
+            // onClose={onCloseRepos}
           />
         }
         contribsFilter={
@@ -216,7 +216,7 @@ export default function Filters({ children }) {
             onApply={onContribsApplyChange}
             value={contribsValue}
             onChange={onSelectContrib}
-            onClose={onCloseContribs}
+            // onClose={onCloseContribs}
           />
         }
         dateIntervalFilter={


### PR DESCRIPTION
Closes: https://athenianco.atlassian.net/browse/ENG-887

how to test:
1) Open any filter repo/users
2) Click an option
3) Open users group, scroll and click an option

Expected result:
No more scrolling to the top or collapsing Groups