### PR TITLE
Enable Created PRs chart in prod

### DIFF
--- a/src/js/components/insights/stages/work-in-progress/index.jsx
+++ b/src/js/components/insights/stages/work-in-progress/index.jsx
@@ -8,8 +8,6 @@ import { InsightsError } from 'js/components/insights/Helper';
 import createdPRs from 'js/components/insights/stages/work-in-progress/createdPrs';
 import mostActiveDevs from 'js/components/insights/stages/work-in-progress/mostActiveDevs';
 import pullRequestRatioFlow from 'js/components/insights/stages/work-in-progress/pullRequestRatioFlow';
-import { isNotProd } from 'js/components/development';
-
 
 export default () => {
     const { api, ready: apiReady, context: apiContext } = useApi();
@@ -52,16 +50,11 @@ const Inner = ({ data, error }) => {
         return <InsightsError/>;
     }
 
-    let insights = [];
-
-    if (isNotProd) {
-        insights.push(createdPRs.factory(data.createdPRs));
-    }
-
-    insights.push(
+    let insights = [
+        createdPRs.factory(data.createdPRs),
         mostActiveDevs.factory(data.mostActiveDevs),
-        pullRequestRatioFlow.factory(data.pullRequestRatioFlow)
-    );
+        pullRequestRatioFlow.factory(data.pullRequestRatioFlow),
+    ];
 
     return (
         <>{insights.map((ins, i) => <Box meta={ins.meta} content={ins.content} key={i} />)}</>

--- a/src/js/services/prHelpers.js
+++ b/src/js/services/prHelpers.js
@@ -169,6 +169,8 @@ export const isInStage = (pr, stage) => {
             case PR_STAGE.WIP:
             case PR_STAGE.DONE:
                 return true;
+            default:
+                throw Error(`unexpected "${stage}" stage`);
         }
     }
 


### PR DESCRIPTION
Addresses [[ENG-761]] [new chart] WIP: Pull Requests created through time
Required by https://github.com/athenianco/athenian-webapp/pull/386#issuecomment-635923470

This will show Created PRs chart into Production

[ENG-761]: https://athenianco.atlassian.net/browse/ENG-761