### PR TITLE
Use react-tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-select": "^3.0.8",
     "react-spinners": "^0.8.1",
     "react-toastify": "^5.5.0",
+    "react-tooltip": "^4.2.6",
     "react-transition-group": "^4.4.1",
     "react-vis": "^1.11.7",
     "superagent": "3.7.0"

--- a/src/js/components/charts/Tooltip.jsx
+++ b/src/js/components/charts/Tooltip.jsx
@@ -157,8 +157,8 @@ const getFilteredObject = (obj, blacklist) => _(obj).omit(blacklist).value();
 
 export const TooltipContainer = ({ left = false, children }) => {
     return (
-        <div className="chart-tooltip" onClick={event => event.stopPropagation()}>
-            <div className="card">
+        <div className="athenian-tooltip chart-tooltip" onClick={event => event.stopPropagation()}>
+            <div>
                 <div className={classnames('card-body p-1', left ? 'text-left' : 'text-center')}>
                     {children}
                 </div>

--- a/src/js/components/pipeline/PullRequests.jsx
+++ b/src/js/components/pipeline/PullRequests.jsx
@@ -143,7 +143,7 @@ const initTable = (stage, users) => {
     .DataTable(tableDefinition)
     .on('draw', () => {
       $('.badge[data-toggle="tooltip"]').tooltip('dispose');
-      $('.athenian-tooltip').remove();
+      $('.athenian-tooltip-table').remove();
       $('.badge[data-toggle="tooltip"]').tooltip(tooltip_conf);
     });
 };
@@ -345,9 +345,7 @@ const getTableDefinition = (stage, users) => {
                 class="badge badge-outlined ${prLabelClasses[prLabelStage(row)]}"
                 data-toggle="tooltip"
               >
-                  <span data-toggle="tooltip" data-placement="bottom" className="ml-2">
-                    ${prLabelStage(row)}
-                  </span>
+                ${prLabelStage(row)}
               </div>`
             );
           case 'type':

--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -12,6 +12,7 @@ import { BigNumber } from 'js/components/ui/Typography';
 import { SmallTitle } from 'js/components/ui/Typography';
 import { StatusIndicator, READY } from 'js/components/ui/Spinner';
 import { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
+import { Tooltip } from 'js/components/ui/Info';
 
 import { pipelineStagesConf } from 'js/pages/pipeline/Pipeline';
 
@@ -196,12 +197,10 @@ const OverviewStageSummaryKPI = ({data}) => {
             (
                 <div key={i}>
                   <div><SmallTitle content={stage.title} /></div>
-                  <span
-                    className={classnames('overall-proportion d-block mb-2', stage.stageName)}
+                  <Tooltip
+                    content={`${dateTime.human(data.avgTimes[stage.metric])} (${number.percentage(data.proportions[stage.metric])})`}
                     style={{ width: `${data.normalizedProportions[stage.metric]}%` }}
-                    data-toggle="tooltip"
-                    data-placement="right"
-                    title={`${dateTime.human(data.avgTimes[stage.metric])} (${number.percentage(data.proportions[stage.metric])})`}
+                    className={classnames('overall-proportion d-block mb-2', stage.stageName)}
                   />
                 </div>
             ) : (

--- a/src/js/components/pipeline/Thumbnails.jsx
+++ b/src/js/components/pipeline/Thumbnails.jsx
@@ -6,7 +6,7 @@ import _ from "lodash";
 import Badge, { NEGATIVE_IS_BETTER } from 'js/components/ui/Badge';
 import { BigNumber, SmallTitle } from 'js/components/ui/Typography';
 import { StatusIndicator, READY } from 'js/components/ui/Spinner';
-import Info from 'js/components/ui/Info';
+import Info, { Tooltip } from 'js/components/ui/Info';
 import PipelineCardMiniChart from 'js/components/pipeline/PipelineCardMiniChart';
 import DataWidget from 'js/components/DataWidget';
 
@@ -32,7 +32,7 @@ const Thumbnails = ({ data, status, activeCard }) => (
 
                   return (
                       <div className={classnames('col-md-3 pipeline-stage', card.stageName, active && 'active')} key={i}>
-                        <span data-toggle="tooltip" data-placement="bottom" title={card.event.before} className="event-before" />
+                        <Tooltip content={card.event.before} className="event-before" />
                         <Link to={'/stage/' + card.slug}>
                           <Stage
                             data={stageData}
@@ -46,7 +46,7 @@ const Thumbnails = ({ data, status, activeCard }) => (
                             badge={completedPRs}
                           />
                         </Link>
-                        <span data-toggle="tooltip" data-placement="bottom" title={card.event.after} className="event-after" />
+                        <Tooltip content={card.event.after} className="event-after" />
                       </div>
                   );
               }

--- a/src/js/components/ui/Info.jsx
+++ b/src/js/components/ui/Info.jsx
@@ -1,23 +1,50 @@
-import React, { useEffect } from 'react';
-import $ from 'jquery';
+import React from 'react';
+import ReactTooltip from 'react-tooltip';
+import classnames from 'classnames';
+import _ from 'lodash';
 
 export const tooltip_conf = {
     html: true,
     placement: 'bottom',
-    template: `<div class="tooltip athenian-tooltip" role="tooltip">
+    template: `<div class="tooltip athenian-tooltip-table" role="tooltip">
         <div class="arrow"></div>
-        <div class="tooltip-inner"></div>
+        <div class="tooltip-inner athenian-tooltip"></div>
       </div>`,
 };
 
 export default ({ content }) => {
-    useEffect(() => {
-        $('[data-toggle="tooltip"]').tooltip && $('[data-toggle="tooltip"]').tooltip(tooltip_conf);
-    }, [])
+  return (
+    <Tooltip content={content} className="ml-2 info-tooltip align-middle">
+      <i className="icon-info"></i>
+    </Tooltip>
+  );
+};
 
-    return (
-        <span data-toggle="tooltip" title={content} className="ml-2 info-tooltip align-middle">
-            <i className="icon-info"></i>
-        </span>
-    );
+export const Tooltip = ({ content, className, style = {}, children }) => {
+  const id = _.uniqueId("prefix-");
+  return (
+    <>
+      <div
+        data-tip
+        data-for={id}
+        className={classnames('d-inline-block', className)}
+        style={_.assign({ pointerEvents: 'auto' }, style)}
+      >
+        {children}
+      </div>
+
+      <ReactTooltip
+        id={id}
+        className="athenian-tooltip"
+        offset={{ top: '4px', left: '0' }}
+        place="bottom"
+        type="light"
+        effect="solid"
+        multiline
+        html
+      >
+        {content}
+      </ReactTooltip>
+    </>
+  );
 };

--- a/src/sass/components/_pipeline.scss
+++ b/src/sass/components/_pipeline.scss
@@ -28,6 +28,7 @@
         &.active {
             z-index: 20;
             border-top-style: solid;
+            pointer-events: none;
 
             a .pipeline-thumbnail.active .text-secondary {
                 color: $white !important;

--- a/src/sass/components/_tooltips.scss
+++ b/src/sass/components/_tooltips.scss
@@ -45,9 +45,19 @@
     line-height: 1.2rem;
 }
 
-// Info tooltips
-
 .athenian-tooltip {
+    max-width: 250px !important;
+    padding: 1rem 1.5rem !important;
+    box-shadow: 0 0 7px rgba(0,0,0,0.2) !important;
+    color: $color-dark !important;
+    background-color: $white !important;
+    font-size: 1.2rem !important;
+    text-align: left !important;
+
+    a {
+        pointer-events: auto !important;
+    }
+
     b {
         display: inline-block;
         margin-top: 1em;
@@ -58,33 +68,24 @@
     }
 }
 
-.tooltip.show {
-    opacity: 1 !important;
-}
+// PR table tooltips (bootstrap tooltips)
 
-.tooltip-inner {
-    max-width: 250px !important;
-    padding: 1rem 1.5rem !important;
-    box-shadow: 0 0 7px rgba(0,0,0,0.2) !important;
-    color: $color-dark !important;
-    background-color: $white !important;
-    font-size: 1.2rem !important;
-    opacity: 1 !important;
-    text-align: left !important;
-}
-
-.bs-tooltip-auto[x-placement^=bottom] .arrow::before, .bs-tooltip-bottom .arrow::before {
+.bs-tooltip-auto[x-placement^=bottom] .arrow::before,
+.bs-tooltip-bottom .arrow::before {
     border-bottom-color: $white !important;
 }
 
-.bs-tooltip-auto[x-placement^=top] .arrow::before, .bs-tooltip-top .arrow::before {
+.bs-tooltip-auto[x-placement^=top] .arrow::before,
+.bs-tooltip-top .arrow::before {
     border-top-color: $white !important;
 }
 
-.bs-tooltip-auto[x-placement^=left] .arrow::before, .bs-tooltip-left .arrow::before {
+.bs-tooltip-auto[x-placement^=left] .arrow::before,
+.bs-tooltip-left .arrow::before {
     border-left-color: $white !important;
 }
 
-.bs-tooltip-auto[x-placement^=right] .arrow::before, .bs-tooltip-right .arrow::before {
+.bs-tooltip-auto[x-placement^=right] .arrow::before,
+.bs-tooltip-right .arrow::before {
     border-right-color: $white !important;
 }

--- a/src/sass/components/_tooltips.scss
+++ b/src/sass/components/_tooltips.scss
@@ -1,22 +1,37 @@
+.athenian-tooltip {
+    width: fit-content !important;
+    max-width: 250px !important;
+    padding: 1rem 1.5rem !important;
+    box-shadow: 0 0 7px rgba(0,0,0,0.2) !important;
+    color: $color-dark !important;
+    background-color: $white !important;
+    font-size: 1.2rem !important;
+    text-align: left !important;
+    border-radius: 0 !important;
+
+    a {
+        pointer-events: auto !important;
+
+        &:hover {
+            text-decoration: underline !important;
+        }
+    }
+
+    b {
+        display: inline-block;
+        margin-top: 1em;
+    }
+
+    .code {
+        font-family: 'Courier New', Courier, monospace;
+    }
+}
+
+// Charts tooltips
+
 .chart-tooltip {
-    background: $white;
-    box-shadow: 0 0 7px rgba(0,0,0,0.2);
-    color: $dark;
-    border-radius: 0;
-    font-size: 1rem;
+    font-size: 1rem !important;
     font-weight: 300;
-    max-width: 250px;
-    padding: 1.5rem;
-    text-align: left;
-    width: fit-content;
-
-    a:hover {
-        text-decoration: underline !important;
-    }
-
-    .card {
-        border: none;
-    }
 
     .mb-2:last-child,
     p:last-child {
@@ -43,29 +58,6 @@
 .info-tooltip {
     font-size: 1.4rem;
     line-height: 1.2rem;
-}
-
-.athenian-tooltip {
-    max-width: 250px !important;
-    padding: 1rem 1.5rem !important;
-    box-shadow: 0 0 7px rgba(0,0,0,0.2) !important;
-    color: $color-dark !important;
-    background-color: $white !important;
-    font-size: 1.2rem !important;
-    text-align: left !important;
-
-    a {
-        pointer-events: auto !important;
-    }
-
-    b {
-        display: inline-block;
-        margin-top: 1em;
-    }
-
-    .code {
-        font-family: 'Courier New', Courier, monospace;
-    }
 }
 
 // PR table tooltips (bootstrap tooltips)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9558,6 +9558,14 @@ react-toastify@^5.5.0:
     prop-types "^15.7.2"
     react-transition-group "^4"
 
+react-tooltip@^4.2.6:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.6.tgz#a3d5f0d1b0c597c0852ba09c5e2af0019b7cfc70"
+  integrity sha512-KX/zCsPFCI8RuulzBX86U+Ur7FvgGNRBdb7dUu0ndo8Urinn48nANq9wfq4ABlehweQjPzLl7XdNAtLKza+I3w==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^4, react-transition-group@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
@@ -11411,6 +11419,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
required by [[DEV-90]] Remove usage of jQuery from webapp

This replaces jQuery tooltips in react components in order to use [`react-tooltip`](https://wwayne.github.io/react-tooltip/) instead.

PR table using `datatables.net` is not a React component, so its tooltips are still jQuery version. 

[DEV-90]: https://athenianco.atlassian.net/browse/DEV-90