### PR TITLE
fix(ENG-979/ENG-973): Make the dev selection independent in the dev filter

### DIFF
--- a/src/js/components/ui/filters/MultiSelect/CustomComponents.jsx
+++ b/src/js/components/ui/filters/MultiSelect/CustomComponents.jsx
@@ -46,11 +46,9 @@ export const Dropdown = ({
   isOpen,
   count,
   setMenuOpen,
-  // onClose
 }) => {
   const close = () => {
     setMenuOpen(!isOpen)
-    // onClose(false)
   }
 
   return (
@@ -150,7 +148,7 @@ export const Group = props => {
     const { data, setValue } = props
     if (!check) {
       const newvalue = values.filter(val => (
-        !data.options.find(op => op.login === val.login)
+        !data.options.find(op => op.login === val.login && op.team === val.team)
       ))
       setValue(newvalue)
     } else {
@@ -253,13 +251,9 @@ export const Menu = (onApply, setMenuOpen) => props => {
 
   const allValues = getValue()
   const mappedOptions = extractOptions(options)
+  const allSelected = allValues.length === mappedOptions.length
+  const isIndeterminate = !allSelected && allValues.length > 0
 
-  const totalOptions = mappedOptions.reduce((acc, curr) => {
-    acc.add(curr.login ? curr.login : curr)
-    return acc
-  }, new Set()).size
-
-  const allSelected = allValues.length === totalOptions
   const toggleAll = () => {
     clearValue()
     if (!allSelected) {
@@ -282,11 +276,11 @@ export const Menu = (onApply, setMenuOpen) => props => {
         className="d-flex filter-dropdown-menu-all"
         onClick={toggleAll}
       >
-        <Checkbox isChecked={allSelected} />
+        <Checkbox isChecked={!!allValues.length} isIndeterminate={isIndeterminate} />
         <span>
           <span className="filter-dropdown-all">All</span>
           <span className="filter-dropdown-pill">
-            {totalOptions}
+            {mappedOptions.length}
           </span>
         </span>
       </div>

--- a/src/js/components/ui/filters/MultiSelect/CustomComponents.jsx
+++ b/src/js/components/ui/filters/MultiSelect/CustomComponents.jsx
@@ -6,6 +6,8 @@ import { ReactComponent as DropdownIndicator } from './IconDropdownIndicator.svg
 import { components } from 'react-select'
 import { github } from 'js/services/format'
 import classNames from 'classnames'
+import _ from 'lodash'
+
 /**
  * Transform string into color
  * @param {string} str
@@ -232,12 +234,15 @@ export const Placeholder = props => {
   */
 const extractOptions = options => {
   const [option] = options
-  if (option && option.options) { //is a group
-    return options.reduce((acc, curr) => {
-      return [ ...acc, ...curr.options ]
-    }, [])
-  }
-  return options
+  const isGroup = option && option.options
+
+  if (!isGroup) return [options, false]
+
+  const groupOptions = options.reduce((acc, curr) => {
+    return [ ...acc, ...curr.options ]
+  }, [])
+
+  return [groupOptions, isGroup]
 }
 
 export const Menu = (onApply, setMenuOpen) => props => {
@@ -250,8 +255,13 @@ export const Menu = (onApply, setMenuOpen) => props => {
   } = props
 
   const allValues = getValue()
-  const mappedOptions = extractOptions(options)
-  const allSelected = allValues.length === mappedOptions.length
+
+  const [mappedOptions, isGroup] = extractOptions(options)
+
+  const allUniqueOptions = isGroup ? _(mappedOptions).uniqBy('login').value() : mappedOptions
+  const allUniqSelect = isGroup ? _(allValues).uniqBy('login').value() : allValues
+  const allSelected = allUniqSelect.length === allUniqueOptions.length
+
   const isIndeterminate = !allSelected && allValues.length > 0
 
   const toggleAll = () => {
@@ -261,7 +271,7 @@ export const Menu = (onApply, setMenuOpen) => props => {
     }
   }
 
-  const close = wasApplied => {
+  const close = () => {
     setMenuOpen(false)
   }
 
@@ -280,7 +290,7 @@ export const Menu = (onApply, setMenuOpen) => props => {
         <span>
           <span className="filter-dropdown-all">All</span>
           <span className="filter-dropdown-pill">
-            {mappedOptions.length}
+            {allUniqueOptions.length}
           </span>
         </span>
       </div>

--- a/src/js/components/ui/filters/MultiSelect/index.jsx
+++ b/src/js/components/ui/filters/MultiSelect/index.jsx
@@ -32,6 +32,7 @@ const MultiSelect = multiSelectProps => {
     isLoading,
     options,
     value,
+    count,
   } = multiSelectProps
 
   const [isMenuOpen, setMenuOpen] = useState(false)
@@ -73,13 +74,13 @@ const MultiSelect = multiSelectProps => {
     (wasApplied) => {
       setMenuOpen()
     }), [onApply])
-
+  
   return (
     <div ref={ref} onClick={toggle}>
       <Dropdown
         label={label}
         isLoading={isLoading}
-        count={value.length}
+        count={count}
         setMenuOpen={setMenuOpen}
         isOpen={isMenuOpen}
         onClose={onClose}

--- a/src/js/components/ui/filters/MultiSelect/index.jsx
+++ b/src/js/components/ui/filters/MultiSelect/index.jsx
@@ -69,10 +69,8 @@ const MultiSelect = multiSelectProps => {
   const Menu = useMemo(() => CustomMenu(
     (values) => {
       onApply(values)
-      // onClose(true)
     },
     (wasApplied) => {
-      // onClose(wasApplied)
       setMenuOpen()
     }), [onApply])
 

--- a/src/js/pages/pipeline/Filters/filterReducer.jsx
+++ b/src/js/pages/pipeline/Filters/filterReducer.jsx
@@ -1,101 +1,113 @@
+const mapTeam = (contribs, teams) => {
+  if (!teams.length) return contribs;
+  return mapContribsToTeam(contribs, teams).reduce((acc, curr) => {
+    return acc.concat(curr.options);
+  }, []);
+};
+
 export const filterReducer = (state, action) => {
   switch (action.type) {
     case TYPE.INIT:
-      const { ready, repos, contribs, teams } = action.payload
+      const { ready, repos, contribs, teams } = action.payload;
+
+      const initTeamsContribs = mapTeam(contribs, teams);
       return {
         ...state,
         ready,
         repos: {
           ready,
-          data: [...repos],
-          selected: [...repos],
-          applied: [...repos]
+          data: repos,
+          selected: repos,
+          applied: repos,
         },
         contribs: {
           ready,
-          data: [...contribs],
-          selected: [...contribs],
-          applied: [...contribs]
+          data: initTeamsContribs,
+          selected: initTeamsContribs,
+          applied: initTeamsContribs,
         },
         teams: {
           ready,
-          data: [...teams]
-        }
-      }
+          data: teams
+        },
+      };
     case TYPE.SET_INTERVAL:
       return {
-        ...state, 
-        dateInterval: action.payload
-      }
-    case TYPE.SET_REPOS: 
+        ...state,
+        dateInterval: action.payload,
+      };
+    case TYPE.SET_REPOS:
       return {
         ...state,
         repos: {
           ...state.repos,
           ready: true,
           data: action.payload,
-          selected: []
-        }
-      }
+          selected: [],
+        },
+      };
     case TYPE.SET_TEAMS:
       return {
         ...state,
         teams: {
           ready: true,
-          data: action.payload
-        }
-      }
+          data: action.payload,
+        },
+      };
     case TYPE.READY:
       return {
         ...state,
-        ready: action.payload
-      }
+        ready: action.payload,
+      };
     case TYPE.SET_CONTRIBS:
-        return {
-          ...state,
-          contribs: {
-            ...state.contribs,
-            ready: true,
-            data: action.payload,
-            selected: []
-          }
-        }
+      return {
+        ...state,
+        contribs: {
+          ...state.contribs,
+          ready: true,
+          data: mapTeam(action.payload, state.teams.data)
+        },
+      };
     case TYPE.SET_SELECTED_REPOS:
-        return {
-          ...state,
-          repos: {
-            ...state.repos,
-            selected: action.payload
-          }
-        }
+      return {
+        ...state,
+        repos: {
+          ...state.repos,
+          selected: action.payload,
+        },
+      };
     case TYPE.SET_SELECTED_CONTRIBS:
-        return {
-          ...state,
-          contribs: {
-            ...state.contribs,
-            selected: action.payload
-          }
-        }
+      const [contrib] = action.payload
+      // if action.payload was not formatted yet use mapTeam
+      // contrib && contrib.team - value comes from onChange of select
+      const selected = contrib && contrib.team ? action.payload : mapTeam(action.payload, state.teams.data)
+      return {
+        ...state,
+        contribs: {
+          ...state.contribs,
+          selected
+        },
+      };
     case TYPE.SET_APPLIED_CONTRIBS:
-        return {
-          ...state,
-          contribs: {
-            ...state.contribs,
-            applied: action.payload
-          }
-        }
+      return {
+        ...state,
+        contribs: {
+          ...state.contribs,
+          applied: mapTeam(action.payload, state.teams.data)
+        },
+      };
     case TYPE.SET_APPLIED_REPOS:
       return {
         ...state,
         repos: {
           ...state.repos,
-          applied: action.payload
-        }
-      }
+          applied: action.payload,
+        },
+      };
     default:
-      return state
+      return state;
   }
-}
+};
 
 export const defaultFilter = {
   ready: false,
@@ -103,86 +115,85 @@ export const defaultFilter = {
     data: [],
     ready: false,
     selected: [],
-    applied: []
+    applied: [],
   },
   teams: {
     data: [],
-    ready: false
+    ready: false,
   },
   contribs: {
     data: [],
     ready: false,
     selected: [],
-    applied: []
+    applied: [],
   },
-  dateInterval: null
-}
+  dateInterval: null,
+};
 
 export const TYPE = {
-  INIT: 'INIT',
-  SET_REPOS: 'SET_REPOS',
-  SET_INTERVAL: 'SET_INTERVAL',
-  SET_TEAMS: 'SET_TEAMS',
-  SET_READY: 'SET_READY',
-  SET_CONTRIBS: 'SET_CONTRIBS',
-  SET_SELECTED_REPOS: 'SET_SELECTED_REPOS',
-  SET_SELECTED_CONTRIBS: 'SET_SELECTED_CONTRIBS',
-  SET_APPLIED_REPOS: 'SET_APPLIED_REPOS',
-  SET_APPLIED_CONTRIBS: 'SET_APPLIED_CONTRIBS'
-}
+  INIT: "INIT",
+  SET_REPOS: "SET_REPOS",
+  SET_INTERVAL: "SET_INTERVAL",
+  SET_TEAMS: "SET_TEAMS",
+  SET_READY: "SET_READY",
+  SET_CONTRIBS: "SET_CONTRIBS",
+  SET_SELECTED_REPOS: "SET_SELECTED_REPOS",
+  SET_SELECTED_CONTRIBS: "SET_SELECTED_CONTRIBS",
+  SET_APPLIED_REPOS: "SET_APPLIED_REPOS",
+  SET_APPLIED_CONTRIBS: "SET_APPLIED_CONTRIBS",
+  READY: 'READY'
+};
 
 /**
  * Merge and map contributors list and teams
  * contributors without a team is left in the 'Other' team
- * @param {Array} contribs 
+ * @param {Array} contribs
  * @param {Array} teams
  */
 export const mapContribsToTeam = (contribs, teams) => {
-  if (!teams.length) return contribs
-
-  const teamsBluePrint = teams.map(({ name, members, id }) => {
-    return {
-      id,
-      label: name,
-      membersSet: members.reduce((acc, curr) => {
-        acc.add(curr.login)
-        return acc
-      }, new Set()),
-      options: []
-    }
-  })
-
-  teamsBluePrint.push({
-    label: 'Other',
-    id: 'other',
-    options: [],
-    membersSet: new Set()
-  })
+  if (!teams.length) return contribs;
 
   const mapMember = ({ login, name, picture, avatar }) => ({
-    login, name, avatar: (picture || avatar)
-  })
+    login,
+    name,
+    avatar: picture || avatar,
+  });
 
-  const otherTeam = teamsBluePrint.length - 1
+  const teamsBlueprint = teams.map(({ name: label, members }) => {
+    return {
+      label,
+      options: members
+        // remove contributors not in the date range
+        .filter(member => contribs.find(contrib => contrib.login === member.login))
+        .map(member => ({ ...mapMember(member), team: label })),
+    };
+  });
 
-  const mappedTeams = contribs.reduce((acc, curr) => {
-    let found = false
-    teamsBluePrint.forEach((team, index, arr) => {
-      if (team.membersSet.has(curr.login)) {
-        found = team.options.push(mapMember(curr))
+  teamsBlueprint.push({
+    label: "Other",
+    options: [],
+  });
+
+  const otherTeam = teamsBlueprint.length - 1;
+
+  const mappedTeams = contribs.reduce((teams, contributor) => {
+    let isContributorAdded = false
+    for (let { options } of teams) {
+      const foundMember = options.find(member => member.login === contributor.login)
+      if (foundMember) {
+        isContributorAdded = true
+        break
       }
-    })
+    }
 
-    if (!found) {
-      teamsBluePrint[otherTeam].options.push({
-        name: curr.name,
-        login: curr.login,
-        avatar: curr.avatar || curr.picture,
-        id: curr.id
+    if (!isContributorAdded) {
+      teams[otherTeam].options.push({
+        ...mapMember(contributor),
+        team: 'Other'
       })
     }
-    return teamsBluePrint
-  }, teamsBluePrint)
+    return teams
+  }, teamsBlueprint)
 
-  return mappedTeams
-}
+  return mappedTeams;
+};

--- a/src/js/pages/pipeline/Filters/index.jsx
+++ b/src/js/pages/pipeline/Filters/index.jsx
@@ -60,12 +60,12 @@ export default function Filters({ children }) {
         getContribsForFilter(tokenRef.current, accountID, filterData.dateInterval, contextRepos),
         getTeamsForFilter(tokenRef.current, accountID)
       ])
-
+  
       setGlobalData(
         ['filter.repos', 'filter.contribs', 'filter.teams'],
         [repos, contribs, teams]
       )
-
+    
       dispatchFilter(init({ repos, contribs, teams, ready: true }))
     })()
   })
@@ -113,11 +113,10 @@ export default function Filters({ children }) {
     )
     
     dispatchFilter(setAppliedRepos(selectedRepos))
-
+    dispatchFilter(setTeams(teams))
     dispatchFilter(setContribs(contribs))
     dispatchFilter(setSelectedContribs(contribs))
-
-    dispatchFilter(setTeams(teams))
+    dispatchFilter(setAppliedContribs(contribs))
     dispatchFilter(setReady(true))
   }, [accountID, contextRepos, filterData.dateInterval, resetData, setGlobalData])
 
@@ -141,7 +140,7 @@ export default function Filters({ children }) {
   
   const reposLabelFormat = repo => (github.repoName(repo) || 'UNKNOWN')
   const getOptionValueRepos = val => val
-  const getOptionValueUsers = val => `${val.id} ${val.name} ${val.login}`
+  const getOptionValueUsers = val => `${val.team} ${val.name} ${val.login}`
 
   const reposOptions = [...filterData.repos.data]
 
@@ -154,7 +153,7 @@ export default function Filters({ children }) {
     dispatchFilter(setSelectedRepos(selectedOptions))
   }
 
-  const onSelectContrib = (selectedContrib, ...rest) => {
+  const onSelectContrib = selectedContrib => {
     dispatchFilter(setSelectedContribs(selectedContrib))
   }
   
@@ -162,22 +161,9 @@ export default function Filters({ children }) {
     ~filterData.repos.selected.indexOf(repo)
   )
 
-  const contribsValue = filterData.contribs.data.filter(c =>
-    filterData.contribs.selected.find(e => e.login === c.login)
+  const teamsValue = filterData.contribs.data.filter(c =>
+    filterData.contribs.selected.find(e => e.login === c.login && e.team === c.team)
   )
-
-  // revert previous values is close filter without apply
-  // const onCloseRepos = useCallback(applied => {
-  //   if (!applied) {
-  //     dispatchFilter(setSelectedRepos([...filterData.repos.applied]))
-  //   }
-  // }, [filterData.repos.applied])
-
-  // const onCloseContribs = useCallback(applied => {
-  //   if (!applied) {
-  //     dispatchFilter(setSelectedContribs([...filterData.contribs.applied]))
-  //   }
-  // }, [filterData.contribs.applied])
 
   return (
     <FiltersContext
@@ -200,7 +186,6 @@ export default function Filters({ children }) {
             onApply={onReposApplyChange}
             onChange={onSelectRepo}
             value={reposValue}
-            // onClose={onCloseRepos}
           />
         }
         contribsFilter={
@@ -214,9 +199,8 @@ export default function Filters({ children }) {
             getOptionValue={getOptionValueUsers}
             options={teamsOptions}
             onApply={onContribsApplyChange}
-            value={contribsValue}
+            value={teamsValue}
             onChange={onSelectContrib}
-            // onClose={onCloseContribs}
           />
         }
         dateIntervalFilter={

--- a/src/js/pages/pipeline/Filters/index.jsx
+++ b/src/js/pages/pipeline/Filters/index.jsx
@@ -1,5 +1,6 @@
 import React, { useReducer, useRef, useCallback } from 'react'
 import moment from 'moment'
+import _ from 'lodash'
 
 import { useAuth0 } from 'js/context/Auth0'
 import { useUserContext } from 'js/context/User'
@@ -165,6 +166,7 @@ export default function Filters({ children }) {
     filterData.contribs.selected.find(e => e.login === c.login && e.team === c.team)
   )
 
+  const totalCountContribs = _(teamsValue).uniqBy('login').value()
   return (
     <FiltersContext
       ready={filterData.ready}
@@ -186,6 +188,7 @@ export default function Filters({ children }) {
             onApply={onReposApplyChange}
             onChange={onSelectRepo}
             value={reposValue}
+            count={reposValue.length}
           />
         }
         contribsFilter={
@@ -201,6 +204,7 @@ export default function Filters({ children }) {
             onApply={onContribsApplyChange}
             value={teamsValue}
             onChange={onSelectContrib}
+            count={totalCountContribs.length}
           />
         }
         dateIntervalFilter={


### PR DESCRIPTION
Closes: https://athenianco.atlassian.net/browse/ENG-973
Closes: https://athenianco.atlassian.net/browse/ENG-979

Makes a developers selection independent from each other, e.g.: If a developer is in "Core team" and also in "Front-end team" we can deselect this developer from one team and not the other.
<img width="339" alt="Screen Shot 2020-06-01 at 10 14 38" src="https://user-images.githubusercontent.com/745366/83412587-bf965380-a3f0-11ea-82a2-20c18d1ae0e8.png">
