### PR TITLE
Fix creation of instance id for QA env due to echo -n different implementations

### DIFF
--- a/Makefile.testenv
+++ b/Makefile.testenv
@@ -3,7 +3,7 @@
 TEST_BRANCH ?=
 TEST_SERVICE_ACCOUNT ?=
 TEST_GCE_IMAGE ?= test-web-app
-TEST_GCE_INSTANCE ?= branch-$(shell sh -c "echo -n $(TEST_BRANCH) | md5sum | cut -c -32")
+TEST_GCE_INSTANCE ?= branch-$(shell sh -c "printf \"%s\" \"$(TEST_BRANCH)\" | md5sum | cut -c -32")
 TEST_GCE_ZONE ?= us-east1-c
 
 .PHONY: check-test-branch


### PR DESCRIPTION
Signed-off-by: Lou Marvin Caraig <loumarvincaraig@gmail.com>