### PR TITLE
Let God Users to impersonate other users from their Profile settings page

### DIFF
--- a/src/js/context/User.jsx
+++ b/src/js/context/User.jsx
@@ -60,7 +60,7 @@ export default ({ children }) => {
     }
 
     return (
-        <UserContext.Provider value={{user: state.user, isAuthenticated, isDemo, logout}}>
+        <UserContext.Provider value={{user: state.user, isAuthenticated, isDemo, logout, godMode: state.godMode}}>
           {children}
         </UserContext.Provider >
     );

--- a/src/js/pages/settings/Profile.jsx
+++ b/src/js/pages/settings/Profile.jsx
@@ -1,51 +1,129 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import classnames from 'classnames';
+import { useHistory} from 'react-router';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { faUserSecret } from '@fortawesome/free-solid-svg-icons';
 
 import defaultImage from 'images/default-user-image.png';
 
 import { useUserContext } from 'js/context/User';
 import { SettingsGroup, getOrg } from 'js/pages/Settings';
+import { useApi } from 'js/hooks';
+import { becomeUser, testGodUser } from 'js/services/api';
+import log from 'js/services/logger';
 
 export default () => {
-  const { user } = useUserContext();
+  const { user, godMode } = useUserContext();
   const org = getOrg(user);
 
   return (
-    <SettingsGroup title="Profile">
-      <p className="text-secondary mt-2 mb-3">User Information</p>
-      <div className="card bg-light mb-5">
-        <div className="card-body d-flex align-items-center">
-          <img className="rounded-circle mr-3" src={user.picture || defaultImage} alt="" width="80" />
-          <div>
-            <h3 className="text-dark text-truncate h5">{user.name} <FontAwesomeIcon icon={faGithub} /></h3>
-            <p className="text-secondary text-truncate font-weight-light mb-0">{user.email}</p>
-          </div>
-        </div>
-      </div>
-      <p className="text-secondary mt-2 mb-3">Organization Information</p>
-      <div className="row mb-3">
-        <div className="form-group col-6">
-          <label>GitHub Handle</label>
-          <div className="input-group">
-            <div className="input-group-prepend">
-              <FontAwesomeIcon icon={faGithub} />
+    <>
+      <SettingsGroup title="Profile">
+        <p className="text-secondary mt-2 mb-3">User Information</p>
+        <div className="card bg-light mb-5">
+          <div className="card-body d-flex align-items-center">
+            <img className="rounded-circle mr-3" src={user.picture || defaultImage} alt="" width="80" />
+            <div>
+              <h3 className="text-dark text-truncate h5">{user.name} <FontAwesomeIcon icon={faGithub} /></h3>
+              <p className="text-secondary text-truncate font-weight-light mb-0">{user.email}</p>
             </div>
-            <input type="text" className="form-control" id="formGroupExampleInput" placeholder={org.name} disabled={true} />
           </div>
         </div>
-      </div>
-      <div className="row">
-        <div className="form-group col-6">
-          <label>GitHub Organization Name</label>
-          <div className="input-group">
-            <div className="input-group-prepend">
-              <FontAwesomeIcon icon={faGithub} />
+
+        <p className="text-secondary mt-2 mb-3">Organization Information</p>
+        <div className="row mb-3">
+          <div className="form-group col-6">
+            <label>GitHub Handle</label>
+            <div className="input-group">
+              <div className="input-group-prepend">
+                <FontAwesomeIcon icon={faGithub} />
+              </div>
+              <input type="text" className="form-control" id="orgHandlerInput" placeholder={org.name} disabled={true} />
             </div>
-            <input type="text" className="form-control" id="formGroupExampleInput" placeholder={org.handler} disabled={true} />
           </div>
         </div>
-      </div>
-    </SettingsGroup>
+        <div className="row">
+          <div className="form-group col-6">
+            <label>GitHub Organization Name</label>
+            <div className="input-group">
+              <div className="input-group-prepend">
+                <FontAwesomeIcon icon={faGithub} />
+              </div>
+              <input type="text" className="form-control" id="orgNameInput" placeholder={org.handler} disabled={true} />
+            </div>
+          </div>
+        </div>
+      </SettingsGroup>
+
+      <Admin userId={user.id} isGodMode={godMode} />
+    </>
   );
+};
+
+const Admin = ({ userId, isGodMode }) => {
+  const history = useHistory();
+  const { api, ready: apiReady } = useApi(true, false);
+  const [targetUserState, setTargetUserState] = useState(isGodMode ? userId : '');
+  const [godUserState, setGodUserState] = useState(isGodMode);
+
+  useEffect(() => {
+    if (!apiReady || isGodMode) {
+      return;
+    }
+
+    (async () => {
+      setGodUserState(await testGodUser(api));
+    })();
+  }, [api, apiReady, isGodMode]);
+
+  const impersonate = async () => {
+    try {
+      await becomeUser(api, targetUserState);
+      history.go();
+    } catch (e) {
+      log.fatal(`Could not impersonate user`, e);
+    }
+  };
+
+  const revert = async () => {
+    try {
+      await becomeUser(api, null);
+      history.go();
+    } catch (e) {
+      log.fatal(`Could not restore user`, e);
+    }
+  };
+
+  if (!godUserState || !apiReady) return null;
+
+  return (
+      <SettingsGroup title="Admin">
+        <p className="text-secondary mb-3">Impersonate user</p>
+        <div className="row">
+          <div className="form-group col-6">
+            <label>User id</label>
+            <div className="input-group">
+              <div className="input-group-prepend">
+                <FontAwesomeIcon icon={faUserSecret} />
+              </div>
+              <input
+                type="text"
+                className={classnames('form-control', !isGodMode && 'enabled')}
+                id="targetUserIdInput"
+                placeholder="github|0000000"
+                value={targetUserState}
+                onChange={e => setTargetUserState(e.target.value)}
+                disabled={isGodMode}
+              />
+              <div className="input-group-append">
+                <button className="btn btn-outline-secondary" type="button" onClick={isGodMode ? revert : impersonate}>
+                  {isGodMode ? 'revert' : 'become'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </SettingsGroup>
+    );
 };

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -390,3 +390,20 @@ export const fetchVersions = async () => {
   );
   return versions;
 };
+
+export const becomeUser = async (api, id) => {
+  return await withSentryCapture(
+    api.becomeUser({id}),
+    `Cannot become user ${id}`,
+    true,
+  );
+};
+
+export const testGodUser = async api => {
+  try {
+    await api.becomeUser();
+    return true;
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/sass/components/_forms.scss
+++ b/src/sass/components/_forms.scss
@@ -10,7 +10,7 @@
     .input-group-prepend {
         position: absolute;
         left: .6rem;
-        z-index: 1;
+        z-index: 10;
         font-size: 2rem;
         top: .6rem;
     }


### PR DESCRIPTION
https://www.loom.com/share/7511504010a3465a81c9048a3d659371

## nice to have

Current API does not expose God capacities under `/user` endpoint, so it's checked directly from the Admin section directly trying to use it. If the user can not use it, the whole admin section is hidden from the Profile page.

It would be better if the God capacities are directly exposed by `/user` endpoint.