### PR TITLE
"Empty" message when there is no data for an insight

### DIFF
--- a/src/js/components/DataWidget.jsx
+++ b/src/js/components/DataWidget.jsx
@@ -74,7 +74,7 @@ export default ({id, component, fetcher, plumber, globalDataIDs, config, propaga
                 console.error(error);
             } else {
                 widgetData = data;
-                status = widgetData ? READY : EMPTY;
+                status = widgetData && !widgetData.empty  ? READY : EMPTY;
             }
 
             console.log(`---> Rendering CHART: useEffect 1 | found ${error ? 'error' : 'data'}:`, error ? error : widgetData);

--- a/src/js/components/insights/Box.jsx
+++ b/src/js/components/insights/Box.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 import Info from 'js/components/ui/Info';
+import { NoData } from '../layout/Empty';
 /*
   Component for the boxes in the "Insights" tab of each stage of the pipeline.
 
@@ -37,9 +38,17 @@ import Info from 'js/components/ui/Info';
 
  */
 export default ({meta, content}) => (
-    <div className="card mb-4">
+    <div className="card insight-card mb-4">
       <BoxHeader meta={meta}/>
-      <BoxBody content={content} />
+      {content?.empty ?
+        (
+          <div className="card-body py-5 px-4">
+            <NoData />
+          </div>
+        ) : (
+          <BoxBody content={content} />
+        )
+      }
     </div >
 );
 
@@ -53,13 +62,20 @@ const BoxHeader = ({meta}) => (
 const BoxBody = ({content}) =>  (
     <>{
         content.map((row, i) => (
-            <div key={i} className="card-body py-5 px-4">{
-                row.kpis.length > 0 ? (
-                    <WithKPIBoxBodyRow chart={row.chart} kpis={row.kpis} />
-                ) : (
-                    <SimpleBoxBodyRow chart={row.chart} />
-                )
-            }</div>
+            <div key={i} className="card-body py-5 px-4">
+                {row?.empty ?
+                    (
+                        <NoData />
+                    ) : (
+                        row.kpis.length > 0 ?
+                            (
+                                <WithKPIBoxBodyRow chart={row.chart} kpis={row.kpis} />
+                            ) : (
+                                <SimpleBoxBodyRow chart={row.chart} />
+                            )
+                    )
+                }
+            </div>
         ))
     }</>
 );

--- a/src/js/components/insights/charts/library/TimeSeries.jsx
+++ b/src/js/components/insights/charts/library/TimeSeries.jsx
@@ -18,7 +18,6 @@ import {
 } from 'react-vis';
 
 import { DateBigNumber, onValueChange, onValueReset } from 'js/components/charts/Tooltip';
-import { NoData } from 'js/components/layout/Empty';
 
 export default ({title, data, extra, ...rest}) => (
     <div style={{ background: 'white' }}>
@@ -71,10 +70,6 @@ const filterEmptyValues = v => v !== null;
 
 const TimeSeries = ({ title, data, extra, timeMode }) => {
     const [currentHover, setCurrentHover] = useState(null);
-
-    if (data.length === 0) {
-        return <NoData textOnly />;
-    }
 
     const formattedData = _(data)
           .map(v => ({

--- a/src/js/components/insights/charts/library/TimeSeries.jsx
+++ b/src/js/components/insights/charts/library/TimeSeries.jsx
@@ -102,7 +102,7 @@ const TimeSeries = ({ title, data, extra, timeMode }) => {
     const tickValues = computeTickValues(formattedData, extra.maxNumberOfTicks);
 
     const referenceData = [];
-    if (extra.reference) {
+    if (extra.reference && dataPoints.length) {
         referenceData.push({
             x: xDomain.min,
             y: extra.reference.value
@@ -114,7 +114,7 @@ const TimeSeries = ({ title, data, extra, timeMode }) => {
     }
 
     const averagedData = [];
-    if (extra.average) {
+    if (extra.average && dataPoints.length) {
         averagedData.push({
             x: xDomain.min,
             y: scaleY(extra.average.value),

--- a/src/js/components/insights/stages/merge/abandonedWork.jsx
+++ b/src/js/components/insights/stages/merge/abandonedWork.jsx
@@ -73,6 +73,7 @@ export default {
         },
         content: [
             {
+                empty: computed.chartData.length === 0,
                 chart: {
                     component: VerticalBarChart,
                     params: {

--- a/src/js/components/insights/stages/merge/mergeDelays.jsx
+++ b/src/js/components/insights/stages/merge/mergeDelays.jsx
@@ -95,6 +95,7 @@ export default {
             },
             content: [
                 {
+                    empty: computed.chartData.length === 0,
                     chart: {
                         component: VerticalBarChart,
                         params: {

--- a/src/js/components/insights/stages/review/pullRequestSize.jsx
+++ b/src/js/components/insights/stages/review/pullRequestSize.jsx
@@ -92,6 +92,7 @@ const pullRequestSize = {
             },
             content: [
                 {
+                    empty: computed.chartData.length === 0,
                     chart: {
                         component: BubbleChart,
                         params: {

--- a/src/js/components/insights/stages/review/reviewActivity.jsx
+++ b/src/js/components/insights/stages/review/reviewActivity.jsx
@@ -152,99 +152,108 @@ const reviewActivity = {
   factory: computed => {
     const createdPRs = computed.firstBox.KPIsData.createdPRs;
     const reviewedPRs = computed.firstBox.KPIsData.reviewedPRs;
-    return {
-      meta: {
-        title: 'Review Activity',
-        description: 'Understand the role of each team member in the review process.'
+
+    const content = [{
+      empty: computed.firstBox.chartData.length === 0,
+      chart: {
+        component: BubbleChart,
+        params: {
+          title: 'Number of Pull Requests created',
+          data: computed.firstBox.chartData,
+          extra: {
+            useImages: true,
+            yAxis: {
+              imageMapping: computed.secondBox.avatarMapping,
+              imageMask: 'circle'
+            },
+            grouper: computed.firstBox.grouper,
+            groups: computed.firstBox.groups,
+            axisKeys: computed.firstBox.axisKeys,
+            axisLabels: {
+              x: 'pull requests reviewed',
+              y: 'pull requests created'
+            },
+            color: '#41CED3',
+            tooltip: { template: UserReviewer },
+          }
+        }
       },
-      content: [{
-        chart: {
-          component: BubbleChart,
+      kpis: [{
+        title: { text: 'Average Pull Requests Reviewed', bold: true },
+        subtitle: { text: 'Per Developer' },
+        component: SimpleKPI,
+        params: {
+          value: number.fixed(computed.firstBox.KPIsData.avgReviewedPRsPerDev, 2),
+        }
+        }, {
+          title: {text: 'Ratio of Pull Requests', bold: true},
+          subtitle: { text: 'Reviewed/Created'},
+          component: SimpleKPI,
           params: {
-            title: 'Number of Pull Requests created',
-            data: computed.firstBox.chartData,
+            value: `${reviewedPRs}/${createdPRs}`
+          }
+        }]
+      },
+      {
+        empty: computed.secondBox.chartData.length === 0,
+        chart: {
+          component: HorizontalBarChart,
+          params: {
+            title: 'Most Active Reviewers',
+            data: computed.secondBox.chartData,
+            tickFormat: tick => `${tick}%`,
             extra: {
-              useImages: true,
               yAxis: {
                 imageMapping: computed.secondBox.avatarMapping,
                 imageMask: 'circle'
               },
-              grouper: computed.firstBox.grouper,
-              groups: computed.firstBox.groups,
-              axisKeys: computed.firstBox.axisKeys,
-              axisLabels: {
-                x: 'pull requests reviewed',
-                y: 'pull requests created'
+              axisKeys: computed.secondBox.axisKeys,
+              series: {
+                prsCommentsPerc: {
+                  name: 'Review comments',
+                  color: '#FC1763',
+                },
+                reviewsPerc: {
+                  name: 'Pull Requests reviewed',
+                  color: '#FFC507',
+                }
               },
-              color: '#41CED3',
               tooltip: { template: UserReviewer },
             }
           }
         },
         kpis: [{
-          title: { text: 'Average Pull Requests Reviewed', bold: true },
-          subtitle: { text: 'Per Developer' },
+          title: {text: 'Total Number of Reviewers', bold: true},
           component: SimpleKPI,
           params: {
-            value: number.fixed(computed.firstBox.KPIsData.avgReviewedPRsPerDev, 2),
+            value: computed.secondBox.KPIsData.reviewers,
           }
-          }, {
-            title: {text: 'Ratio of Pull Requests', bold: true},
-            subtitle: { text: 'Reviewed/Created'},
-            component: SimpleKPI,
-            params: {
-              value: `${reviewedPRs}/${createdPRs}`
-            }
-          }]
         },
         {
-          chart: {
-            component: HorizontalBarChart,
-            params: {
-              title: 'Most Active Reviewers',
-              data: computed.secondBox.chartData,
-              tickFormat: tick => `${tick}%`,
-              extra: {
-                yAxis: {
-                  imageMapping: computed.secondBox.avatarMapping,
-                  imageMask: 'circle'
-                },
-                axisKeys: computed.secondBox.axisKeys,
-                series: {
-                  prsCommentsPerc: {
-                    name: 'Review comments',
-                    color: '#FC1763',
-                  },
-                  reviewsPerc: {
-                    name: 'Pull Requests reviewed',
-                    color: '#FFC507',
-                  }
-                },
-                tooltip: { template: UserReviewer },
-              }
-            }
+          title: {text: 'Proportion of Reviews Comments Made By', bold: true},
+          subtitle: {
+            text: computed.secondBox.KPIsData.topReviewer ?
+            computed.secondBox.KPIsData.topReviewer.developer : ''
           },
-          kpis: [{
-            title: {text: 'Total Number of Reviewers', bold: true},
-            component: SimpleKPI,
-            params: {
-              value: computed.secondBox.KPIsData.reviewers,
-            }
-          },
-          {
-            title: {text: 'Proportion of Reviews Comments Made By', bold: true},
-            subtitle: {
-              text: computed.secondBox.KPIsData.topReviewer ?
-              computed.secondBox.KPIsData.topReviewer.developer : ''
-            },
-            component: SimpleKPI,
-            params: {
-              value: computed.secondBox.KPIsData.topReviewer ?
-              number.fixed(computed.secondBox.KPIsData.topReviewer.prsCommentsPerc,2) : '',
-              unit: '%'
-            }
-          }]
-      }]
+          component: SimpleKPI,
+          params: {
+            value: computed.secondBox.KPIsData.topReviewer ?
+            number.fixed(computed.secondBox.KPIsData.topReviewer.prsCommentsPerc,2) : '',
+            unit: '%'
+          }
+        }]
+    }];
+
+    if (content.filter(c => !c.empty).length === 0) {
+      content.empty = true;
+    }
+
+    return {
+      meta: {
+        title: 'Review Activity',
+        description: 'Understand the role of each team member in the review process.'
+      },
+      content
     };
   }
 };

--- a/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
+++ b/src/js/components/insights/stages/review/waitTimeFirstReview.jsx
@@ -49,6 +49,7 @@ const waitTimeFirstReview = {
             },
             content: [
                 {
+                    empty: computed.chartData.filter(v => v[computed.axisKeys.y] !== null).length === 0,
                     chart: {
                         component: TimeSeries,
                         params: {

--- a/src/js/components/insights/stages/work-in-progress/createdPrs.jsx
+++ b/src/js/components/insights/stages/work-in-progress/createdPrs.jsx
@@ -51,6 +51,7 @@ export default {
         },
         content: [
             {
+                empty: computed.chartData.filter(v => v[computed.axisKeys.y] !== null).length === 0,
                 chart: {
                     component: VerticalBarChart,
                     params: {

--- a/src/js/components/insights/stages/work-in-progress/mostActiveDevs.jsx
+++ b/src/js/components/insights/stages/work-in-progress/mostActiveDevs.jsx
@@ -53,6 +53,7 @@ const mostActiveDevs = {
         },
         content: [
             {
+                empty: computed.chartData.length === 0,
                 chart: {
                     component: HorizontalBarChart,
                     params: {

--- a/src/js/components/insights/stages/work-in-progress/pullRequestPerRepo.jsx
+++ b/src/js/components/insights/stages/work-in-progress/pullRequestPerRepo.jsx
@@ -46,6 +46,7 @@ export default {
             },
             content: [
                 {
+                    empty: computed.chartData.filter(v => v[computed.axisKeys.y] !== 0).length === 0,
                     chart: {
                         component: VerticalBarChart,
                         params: {

--- a/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
+++ b/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
@@ -75,6 +75,7 @@ const pullRequestRatioFlow = {
         },
         content: [
             {
+                empty: computed.chartData.filter(v => v[computed.axisKeys.y] !== null).length === 0,
                 chart: {
                     component: TimeSeries,
                     params: {

--- a/src/js/components/layout/Empty.jsx
+++ b/src/js/components/layout/Empty.jsx
@@ -5,8 +5,8 @@ import comingSoon from 'images/empty-states/coming-soon.svg';
 const Empty = ({ background, children }) => {
     return (
         <div className="row">
-            <div className="col-12 text-center my-5 py-5">
-                <img className="mb-5" src={background} alt="" width="300" />
+            <div className="empty-container col-12 text-center my-5 py-5">
+                <img className="empty-image mb-5" src={background} alt="" width="300" />
                 {children}
             </div>
         </div>

--- a/src/js/components/pipeline/StageMetrics.jsx
+++ b/src/js/components/pipeline/StageMetrics.jsx
@@ -34,14 +34,16 @@ export const StageSummaryMetrics = ({name, stage}) => {
                 data.global['prs-metrics.values'].all['cycle-time'] * 100
         );
 
+        const timeseries= _(data.global['prs-metrics.values'].custom[metric])
+          .map(d => ({x: d.date, y: d.value}));
+
         return (
             {
                 kpisData: stage.summary(proportion, data.global.prs.prs, apiContext.interval),
                 average: data.global['prs-metrics.values'].all[metric],
                 variation: data.global['prs-metrics.variations'][metric],
-                timeseries: _(data.global['prs-metrics.values'].custom[metric])
-                    .map(d => ({x: d.date, y: d.value}))
-                    .value()
+                timeseries: timeseries.value(),
+                empty: timeseries.filter(v => v.y !== null).size() === 0,
             }
         );
     };
@@ -84,6 +86,9 @@ export const OverviewSummaryMetrics = ({name, metric}) => {
               .mapValues(v => v / fastest * 100)
               .value();
 
+        const timeseries = _(data.global['prs-metrics.values'].custom[metric])
+              .map(d => ({x: d.date, y: d.value}));
+
         return (
             {
                 kpisData: {
@@ -93,9 +98,8 @@ export const OverviewSummaryMetrics = ({name, metric}) => {
                 },
                 average: data.global['prs-metrics.values'].all[metric],
                 variation: data.global['prs-metrics.variations'][metric],
-                timeseries: _(data.global['prs-metrics.values'].custom[metric])
-                    .map(d => ({x: d.date, y: d.value}))
-                    .value()
+                timeseries: timeseries.value(),
+                empty: timeseries.filter(v => v.y !== null).size() === 0,
             }
         );
     };
@@ -144,7 +148,7 @@ const SummaryMetrics = ({ data, stage, KPIComponent, status, chartConfig }) => {
     }
 
     return (
-        <div className={classnames('summary-metric card mb-4 px-2', stage.stageName)}>
+        <div className={classnames('card summary-metric mb-4 px-2', stage.stageName)}>
           <div className="card-body" style={{minHeight: '305px'}}>
             <div className="row">
               <div className="col-4">

--- a/src/sass/components/_charts.scss
+++ b/src/sass/components/_charts.scss
@@ -25,7 +25,8 @@
 
 // DataWidget having no data
 
-.insight-card {
+.insight-card,
+.summary-metric {
     .empty-container {
         margin-top: auto !important;
         margin-bottom: auto !important;

--- a/src/sass/components/_charts.scss
+++ b/src/sass/components/_charts.scss
@@ -22,3 +22,33 @@
     margin-left: 10px !important;
     vertical-align: middle;
 }
+
+// DataWidget having no data
+
+.insight-card {
+    .empty-container {
+        margin-top: auto !important;
+        margin-bottom: auto !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+
+        .empty-image {
+            width: auto;
+            height: 150px;
+        }
+
+        h3.text-secondary {
+            font-size: 1.2em;
+            font-weight: 400 !important;
+        }
+
+        p.text-secondary {
+            font-size: 1em;
+            margin-bottom: 0;
+        }
+    }
+}
+
+.summary-metric .empty-container {
+    margin-top: -40px !important;
+}


### PR DESCRIPTION
required by [[DEV-189]] Display an informative visual when no data is available for the summary charts

-----

**note**: `insight` represents a single block of the webapp containing a chart and some optional data (KPIs and such), which is a candidate to be considered "Empty" under certain circumstances.

-----

Each `insight` is compounded of many pieces of information (KPIs, chart data, averages...), so there may be no a single way to define **WHEN** an `insight` must be considered "empty", nor **HOW** to show the "Empty" message; thus, each `insight` must provide its logic to be considered "empty".

For this initial iteration:
- an `insight` will be considered as "empty" **WHEN** there is no data to be plotted in the chart &mdash;no matter the rest of the info&mdash;.
- the way **HOW** an `insight` shows the "Empty" message is:
  - removing its content, but the card title, and
  - centering the same predefined "Empty" message in `insight` container.

In further iterations, each `insight` may define **WHEN** it must be considered "empty", and **HOW** to show the "Empty" message.

![image](https://user-images.githubusercontent.com/2437584/83914617-dc74b300-a771-11ea-9f20-19a6ed449abf.png)

You can see below the `Overview Summary Metric` when there is no data:

![image](https://user-images.githubusercontent.com/2437584/83914599-d1218780-a771-11ea-82f9-f5cee96933bb.png)


## TL;DR

`DataWidget` handles the "empty" criteria showing the Empty message for its plumbed data.
But in some circumstances, `DataWidget` is in charge of rendering many `insights` at once &mdash; like the thumbnails, or the stage insights&mdash;. In such circumstances, each `insight` block must be responsible of showing the "Empty" message following its own criteria.


[DEV-189]: https://athenianco.atlassian.net/browse/DEV-189