### PR TITLE
Show error message when a component could not fetch data.

### DIFF
--- a/src/js/components/DataWidget.jsx
+++ b/src/js/components/DataWidget.jsx
@@ -93,7 +93,7 @@ export default ({id, component, fetcher, plumber, globalDataIDs, config, propaga
     return <Component data={dataState} error={errorState} status={statusState} {...conf} />;
 };
 
-const asError = something => {
+export const asError = something => {
     if (!something) {
         return null;
     }

--- a/src/js/components/DataWidget.jsx
+++ b/src/js/components/DataWidget.jsx
@@ -30,7 +30,13 @@ export default ({id, component, fetcher, plumber, globalDataIDs, config, propaga
                         throw Error(`Missing global data with id ${gid} for data widget with id ${id}`);
                     }
 
-                    globalData[gid] = await d;
+                    const globalDataResolved = await d;
+                    const err = asError(globalDataResolved)
+                    if (err) {
+                        throw err;
+                    }
+
+                    globalData[gid] = globalDataResolved;
                 }
 
                 const plumbedData = plumber({...fetched, global: globalData});

--- a/src/js/pages/pipeline/Stage.jsx
+++ b/src/js/pages/pipeline/Stage.jsx
@@ -9,10 +9,11 @@ import { LOADING, READY, FAILED, EMPTY } from 'js/components/ui/Spinner';
 
 import { pipelineStagesConf, getStage } from 'js/pages/pipeline/Pipeline';
 import { useDataContext } from 'js/context/Data';
+import { asError } from 'js/components/DataWidget';
 
 export default () => {
     const { getGlobal: getGlobalData, globalDataReady } = useDataContext();
-    const [prsState, setPRsState] = useState({ prs: [], users: [] });
+    const [prsState, setPRsState] = useState({ prs: [], users: {} });
     const [statusState, setStatusState] = useState(EMPTY);
 
     useEffect(() => {
@@ -25,6 +26,11 @@ export default () => {
             setStatusState(LOADING);
             try {
                 const prs = await getGlobalData('prs');
+                const err = asError(prs);
+                if (err) {
+                    throw err;
+                }
+
                 setPRsState(prs);
                 setStatusState(prs?.prs?.length ? READY : EMPTY);
             } catch (err) {

--- a/src/js/services/api/index.js
+++ b/src/js/services/api/index.js
@@ -260,7 +260,8 @@ export const fetchFilteredPRs = async (
 
     const prs = await withSentryCapture(
         api.filterPrs({ filterPullRequestsRequest: filter_ }),
-        "Cannot fetch filtered pull requests"
+        "Cannot fetch filtered pull requests",
+        true,
     );
 
     return {
@@ -315,7 +316,8 @@ export const fetchPRsMetrics = async (
 
   return withSentryCapture(
     api.calcMetricsPrLinear(body),
-    "Cannot fetch pull requests metrics"
+    "Cannot fetch pull requests metrics",
+    true,
   );
 };
 


### PR DESCRIPTION
caused by [[DEV-203]], as described by [DEV-203#13049](https://athenianco.atlassian.net/browse/DEV-203?focusedCommentId=13049)

If the API fails, instead of neverending spinners it will be shown a proper error message.

Each `<DataWidget>` component trying to use some data from the API will show an error message if its data could not be retrieved

In the following screenshot, the API was forced to return a `403 Error` for all `/filter/pull_requests` and `/metrics/prs`; that's because user image and filters loaded, but the rest of the components relying on the failing endpoints show an error.

![image](https://user-images.githubusercontent.com/2437584/83802314-d071ee00-a6aa-11ea-8619-7edc0230963f.png)


[DEV-203]: https://athenianco.atlassian.net/browse/DEV-203