### PR TITLE
Changing viewport to make it more usable on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=0.1" />
         <meta name="theme-color" content="#515d5e" />
         <meta
             name="description"


### PR DESCRIPTION
This solves the issue [#DEV-212](https://athenianco.atlassian.net/browse/DEV-212). 

I changed the viewport `initial-scale` to `0.1` to display the whole `webapp` on mobile without the breaking points. This is a temporary solution until we decide how to proceed with mobile screens properly.

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>