### PR TITLE
Adding open graph meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,13 @@
             name="description"
             content="Athenian. Metrics & Insights for Modern Engineering Teams. Reduce your change lead time by supporting your team with the right metrics and insights."
         />
+        <meta content="Athenian - Metrics & Insights For Modern Engineering Teams" property="og:title">
+        <meta content="Bringing metrics and insights to software engineering teams who want to continuously improve. Built for GitHub and Jira." property="og:description">
+        <meta content="https://uploads-ssl.webflow.com/5de5569863e17bd0e3539609/5ec68910df53aa3734de741b_athenian_share_img_v1.jpg" property="og:image">
+        <meta content="Athenian - Metrics & Insights For Modern Engineering Teams" property="twitter:title">
+        <meta content="Bringing metrics and insights to software engineering teams who want to continuously improve. Built for GitHub and Jira." property="twitter:description">
+        <meta content="https://uploads-ssl.webflow.com/5de5569863e17bd0e3539609/5ec68910df53aa3734de741b_athenian_share_img_v1.jpg" property="twitter:image">
+        <meta property="og:type" content="website">
         <link rel="apple-touch-icon" href="logo-192.png" />
         <!--
              manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
This is related to the issue [#DEV-213](https://athenianco.atlassian.net/browse/DEV-213). It adds the open graph meta tags to display the proper information when sharing the webapp.

Signed-off-by: Zuri Negrín <zurinegrin@gmail.com>