### PR TITLE
Make date interval change re-trigger api calls for charts re-rendering

### DIFF
--- a/src/js/pages/pipeline/Filters/index.jsx
+++ b/src/js/pages/pipeline/Filters/index.jsx
@@ -71,10 +71,17 @@ export default function Filters({ children }) {
 
   const onDateIntervalChange = async selectedDateInterval => {
     dispatchFilter(setReady(false))
+    resetData()
+
     const updatedRepos = await getReposForFilter(
       tokenRef.current, accountID, selectedDateInterval)
     const updatedContribs = await getContribsForFilter(
       tokenRef.current, accountID, selectedDateInterval, updatedRepos)
+
+    setGlobalData(
+      ['filter.repos', 'filter.contribs', 'filter.teams'],
+      [filterData.repos.applied, filterData.contribs.applied, filterData.teams.data]
+    )
 
     dispatchFilter(setExcludeInactive(excludeInactive))
     dispatchFilter(setDateInterval(selectedDateInterval))


### PR DESCRIPTION
Fixes the date interval change not retriggering the api calls for refreshing the charts. The bug has been introduced [here](https://github.com/athenianco/athenian-webapp/pull/421/commits/177b5c5eb161a5e6e1798dab3a452749a6adddc1) in https://github.com/athenianco/athenian-webapp/pull/421.