### PR TITLE
fix(DEV-125): Strange hover behavior on PR ratio flow chart

### DIFF
--- a/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
+++ b/src/js/components/insights/stages/work-in-progress/pullRequestRatioFlow.jsx
@@ -36,8 +36,8 @@ const pullRequestRatioFlow = {
                     const ratio = v[0].value;
                     const opened = v[1].value;
                     const closed = v[2].value;
-                    const trickedOpened = opened !== null || closed !== null ? opened + 1 : null;
-                    const trickedClosed = opened !== null || closed !== null ? closed + 1 : null;
+                    const trickedOpened = opened !== null || closed !== null ? (opened + 1).toFixed() : null;
+                    const trickedClosed = opened !== null || closed !== null ? (closed + 1).toFixed() : null;
                     return {
                         day: v[0].date,
                         value: ratio,


### PR DESCRIPTION
Closes: https://athenianco.atlassian.net/browse/DEV-125

It's very tricky to test:
- Go to WIP
- Scroll to Pull Request Ratio Flow
- hover the points as fast as possible, it'll cause a glitch showing a long numbers

this PR just makes sure to show a fixed integer.